### PR TITLE
feat(task-03): tracer — NodeSDK init, OTLP exporters, metric reader

### DIFF
--- a/packages/instrumentation/src/tracer.ts
+++ b/packages/instrumentation/src/tracer.ts
@@ -1,0 +1,48 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import type { ToadEyeConfig } from "./types.js";
+
+const DEFAULT_ENDPOINT = "http://localhost:4318";
+
+let sdk: NodeSDK | null = null;
+
+export function initObservability(config: ToadEyeConfig) {
+  if (sdk) return;
+
+  const endpoint = config.endpoint ?? DEFAULT_ENDPOINT;
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: config.serviceName,
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: `${endpoint}/v1/traces`,
+  });
+
+  const metricExporter = new OTLPMetricExporter({
+    url: `${endpoint}/v1/metrics`,
+  });
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    exportIntervalMillis: 5000,
+  });
+
+  sdk = new NodeSDK({
+    resource,
+    traceExporter,
+    metricReader,
+  });
+
+  sdk.start();
+}
+
+export function shutdown() {
+  if (!sdk) return;
+  sdk.shutdown();
+  sdk = null;
+}


### PR DESCRIPTION
## Summary
- Implement `initObservability()` with NodeSDK, OTLP trace/metric exporters
- Implement `shutdown()` for graceful cleanup
- Singleton guard to prevent double initialization

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] OTel Collector receives traces/metrics when demo runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)