### PR TITLE
refactor(task-08): code polish — DRY, constants, recordContent, badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,43 @@
 # toad-eye 🐸👁️
 
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
+![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-000000?logo=opentelemetry&logoColor=white)
+![Hono](https://img.shields.io/badge/Hono-E36002?logo=hono&logoColor=white)
+![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?logo=prometheus&logoColor=white)
+![Grafana](https://img.shields.io/badge/Grafana-F46800?logo=grafana&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
+![CI](https://github.com/vola-trebla/toad-eye/actions/workflows/ci.yml/badge.svg)
+![License](https://img.shields.io/badge/License-ISC-blue)
+
 OpenTelemetry-based observability toolkit for LLM systems.
 
 One-line instrumentation for any LLM service — get traces, metrics, and Grafana dashboards out of the box.
 
-## What it does
+## Why toad-eye?
 
-```
-Your LLM service
-       ↓ imports
-@toad-eye/instrumentation     ← NPM package, one-line init
-       ↓ OTLP/HTTP
-OTel Collector → Prometheus   ← metrics (cost, latency, tokens)
-               → Jaeger       ← traces (full request lifecycle)
-               → Grafana      ← dashboards
+LLM APIs are black boxes — you don't know what they cost, how slow they are, or why they fail. toad-eye gives you full visibility with one line of code.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    App["🔮 Your LLM service"]
+    Inst["🐸 @toad-eye/instrumentation"]
+    Coll["📡 OTel Collector"]
+    Prom["📊 Prometheus"]
+    Jaeger["🔍 Jaeger"]
+    Graf["📈 Grafana"]
+
+    App --> Inst --> Coll
+    Coll --> Prom --> Graf
+    Coll --> Jaeger
+
+    style App fill:#4a5568,stroke:#718096,color:#fff
+    style Inst fill:#2d6a4f,stroke:#40916c,color:#fff
+    style Coll fill:#1d4ed8,stroke:#3b82f6,color:#fff
+    style Prom fill:#e24d1e,stroke:#ff6633,color:#fff
+    style Jaeger fill:#00bcd4,stroke:#26c6da,color:#fff
+    style Graf fill:#f46800,stroke:#ff8c00,color:#fff
 ```
 
 ## Quick start
@@ -22,19 +46,64 @@ OTel Collector → Prometheus   ← metrics (cost, latency, tokens)
 npm install
 cd infra && docker compose up -d   # start observability stack
 npm run demo                        # start mock LLM service
-# open http://localhost:3000        # Grafana dashboards
+npm run load --workspace=demo       # send test traffic
 ```
+
+| Service        | URL                                       |
+| -------------- | ----------------------------------------- |
+| Grafana        | [localhost:3000](http://localhost:3000)   |
+| Jaeger UI      | [localhost:16686](http://localhost:16686) |
+| Prometheus     | [localhost:9090](http://localhost:9090)   |
+| OTel Collector | [localhost:4318](http://localhost:4318)   |
 
 ## Usage
 
 ```typescript
-import { initObservability } from "@toad-eye/instrumentation";
+import { initObservability, traceLLMCall } from "@toad-eye/instrumentation";
 
+// one-line init
 initObservability({
   serviceName: "my-llm-service",
   endpoint: "http://localhost:4318",
 });
+
+// wrap any LLM call
+const result = await traceLLMCall(
+  { provider: "anthropic", model: "claude-sonnet-4-20250514", prompt: "hello" },
+  () => callYourLLM(),
+);
 ```
+
+> **Privacy mode:** pass `recordContent: false` to `initObservability()` to stop recording prompt/completion text in spans. Useful in production when prompts contain sensitive data.
+
+## What it tracks
+
+### Metrics
+
+| Metric                 | Type      | Description                            |
+| ---------------------- | --------- | -------------------------------------- |
+| `llm.request.duration` | Histogram | Request latency in milliseconds        |
+| `llm.request.cost`     | Histogram | Cost per request in USD                |
+| `llm.tokens`           | Counter   | Total tokens consumed (input + output) |
+| `llm.requests`         | Counter   | Total requests made                    |
+| `llm.errors`           | Counter   | Total failed requests                  |
+
+All metrics are labeled with `provider` and `model` for filtering and grouping.
+
+### Span attributes
+
+| Attribute           | Type   | Description                     |
+| ------------------- | ------ | ------------------------------- |
+| `llm.provider`      | string | `anthropic`, `gemini`, `openai` |
+| `llm.model`         | string | Model identifier                |
+| `llm.prompt`        | string | Prompt sent to the LLM          |
+| `llm.completion`    | string | Response from the LLM           |
+| `llm.input_tokens`  | number | Tokens in the prompt            |
+| `llm.output_tokens` | number | Tokens in the completion        |
+| `llm.cost`          | number | Cost in USD                     |
+| `llm.temperature`   | number | Temperature parameter           |
+| `llm.status`        | string | `success` or `error`            |
+| `llm.error`         | string | Error message (if failed)       |
 
 ## Grafana dashboard
 
@@ -57,17 +126,3 @@ infra/                      — docker-compose stack (OTel + Prometheus + Jaeger
 - TypeScript, OpenTelemetry SDK 2.x, OTLP exporters
 - Hono (demo server)
 - Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector)
-
-## Part of portfolio
-
-Project #7 in [LLM Infrastructure](https://github.com/albertalov/llm-infrastructure) series.
-
-| #   | Project                          | Status |
-| --- | -------------------------------- | ------ |
-| 1   | RAG Ingestion Toolkit            | ✅     |
-| 2   | Guardrails SDK                   | ✅     |
-| 3   | LLM Eval Framework               | ✅     |
-| 4   | LLM Gateway                      | ✅     |
-| 5   | Agentic Tool Router              | ✅     |
-| 6   | Semantic Search Engine           | ✅     |
-| 7   | **LLM Observability (toad-eye)** | 🔨     |

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -1,4 +1,4 @@
-export { initObservability, shutdown } from "./tracer.js";
+export { initObservability, shutdown, getConfig } from "./tracer.js";
 export { traceLLMCall } from "./spans.js";
 export type { LLMCallInput, LLMCallOutput } from "./spans.js";
 export type {
@@ -8,4 +8,4 @@ export type {
   SpanStatus,
   MetricName,
 } from "./types.js";
-export { LLM_METRICS } from "./types.js";
+export { LLM_METRICS, LLM_ATTRS } from "./types.js";

--- a/packages/instrumentation/src/metrics.ts
+++ b/packages/instrumentation/src/metrics.ts
@@ -1,6 +1,6 @@
 import { metrics } from "@opentelemetry/api";
 import type { Counter, Histogram } from "@opentelemetry/api";
-import { LLM_METRICS } from "./types.js";
+import { LLM_METRICS, INSTRUMENTATION_NAME } from "./types.js";
 
 let requestDuration: Histogram;
 let requestCost: Histogram;
@@ -13,7 +13,7 @@ let initialized = false;
 export function initMetrics() {
   if (initialized) return;
 
-  const meter = metrics.getMeter("toad-eye");
+  const meter = metrics.getMeter(INSTRUMENTATION_NAME);
 
   requestDuration = meter.createHistogram(LLM_METRICS.REQUEST_DURATION, {
     description: "LLM request duration in milliseconds",

--- a/packages/instrumentation/src/spans.ts
+++ b/packages/instrumentation/src/spans.ts
@@ -1,5 +1,6 @@
-import { trace, SpanStatusCode } from "@opentelemetry/api";
+import { trace, type Span, SpanStatusCode } from "@opentelemetry/api";
 import type { LLMSpanAttributes } from "./types.js";
+import { LLM_ATTRS, INSTRUMENTATION_NAME } from "./types.js";
 import {
   recordRequestDuration,
   recordRequestCost,
@@ -7,6 +8,7 @@ import {
   recordRequest,
   recordError,
 } from "./metrics.js";
+import { getConfig } from "./tracer.js";
 
 /** Input for traceLLMCall — what the user knows before calling the LLM */
 export interface LLMCallInput {
@@ -24,7 +26,20 @@ export interface LLMCallOutput {
   readonly cost: number;
 }
 
-const tracer = trace.getTracer("toad-eye");
+const tracer = trace.getTracer(INSTRUMENTATION_NAME);
+
+function shouldRecordContent() {
+  return getConfig()?.recordContent !== false;
+}
+
+function setBaseAttributes(span: Span, input: LLMCallInput) {
+  span.setAttributes({
+    [LLM_ATTRS.PROVIDER]: input.provider,
+    [LLM_ATTRS.MODEL]: input.model,
+    [LLM_ATTRS.TEMPERATURE]: input.temperature ?? 1.0,
+    ...(shouldRecordContent() && { [LLM_ATTRS.PROMPT]: input.prompt }),
+  });
+}
 
 export async function traceLLMCall(
   input: LLMCallInput,
@@ -34,23 +49,21 @@ export async function traceLLMCall(
     `llm.${input.provider}.${input.model}`,
     async (span) => {
       const start = performance.now();
+      setBaseAttributes(span, input);
 
       try {
         const output = await fn();
         const duration = performance.now() - start;
 
         span.setAttributes({
-          "llm.provider": input.provider,
-          "llm.model": input.model,
-          "llm.prompt": input.prompt,
-          "llm.completion": output.completion,
-          "llm.input_tokens": output.inputTokens,
-          "llm.output_tokens": output.outputTokens,
-          "llm.cost": output.cost,
-          "llm.temperature": input.temperature ?? 1.0,
-          "llm.status": "success",
+          ...(shouldRecordContent() && {
+            [LLM_ATTRS.COMPLETION]: output.completion,
+          }),
+          [LLM_ATTRS.INPUT_TOKENS]: output.inputTokens,
+          [LLM_ATTRS.OUTPUT_TOKENS]: output.outputTokens,
+          [LLM_ATTRS.COST]: output.cost,
+          [LLM_ATTRS.STATUS]: "success",
         });
-
         span.setStatus({ code: SpanStatusCode.OK });
 
         recordRequest(input.provider, input.model);
@@ -68,18 +81,13 @@ export async function traceLLMCall(
         const message = error instanceof Error ? error.message : String(error);
 
         span.setAttributes({
-          "llm.provider": input.provider,
-          "llm.model": input.model,
-          "llm.prompt": input.prompt,
-          "llm.completion": "",
-          "llm.input_tokens": 0,
-          "llm.output_tokens": 0,
-          "llm.cost": 0,
-          "llm.temperature": input.temperature ?? 1.0,
-          "llm.status": "error",
-          "llm.error": message,
+          [LLM_ATTRS.COMPLETION]: "",
+          [LLM_ATTRS.INPUT_TOKENS]: 0,
+          [LLM_ATTRS.OUTPUT_TOKENS]: 0,
+          [LLM_ATTRS.COST]: 0,
+          [LLM_ATTRS.STATUS]: "error",
+          [LLM_ATTRS.ERROR]: message,
         });
-
         span.setStatus({ code: SpanStatusCode.ERROR, message });
 
         recordRequest(input.provider, input.model);

--- a/packages/instrumentation/src/tracer.ts
+++ b/packages/instrumentation/src/tracer.ts
@@ -10,6 +10,11 @@ import { initMetrics } from "./metrics.js";
 const DEFAULT_ENDPOINT = "http://localhost:4318";
 
 let sdk: NodeSDK | null = null;
+let currentConfig: ToadEyeConfig | null = null;
+
+export function getConfig() {
+  return currentConfig;
+}
 
 export function initObservability(config: ToadEyeConfig) {
   if (sdk) return;
@@ -40,11 +45,13 @@ export function initObservability(config: ToadEyeConfig) {
   });
 
   sdk.start();
+  currentConfig = config;
   initMetrics();
 }
 
-export function shutdown() {
+export async function shutdown() {
   if (!sdk) return;
-  sdk.shutdown();
+  await sdk.shutdown();
   sdk = null;
+  currentConfig = null;
 }

--- a/packages/instrumentation/src/types.ts
+++ b/packages/instrumentation/src/types.ts
@@ -1,3 +1,5 @@
+export const INSTRUMENTATION_NAME = "toad-eye";
+
 /**
  * LLM providers supported by toad-eye
  */
@@ -39,6 +41,23 @@ export const LLM_METRICS = {
   TOKENS: "llm.tokens",
   REQUESTS: "llm.requests",
   ERRORS: "llm.errors",
+} as const;
+
+/**
+ * Span attribute keys attached to every LLM span.
+ * Using constants prevents typos and enables rename-refactoring.
+ */
+export const LLM_ATTRS = {
+  PROVIDER: "llm.provider",
+  MODEL: "llm.model",
+  PROMPT: "llm.prompt",
+  COMPLETION: "llm.completion",
+  INPUT_TOKENS: "llm.input_tokens",
+  OUTPUT_TOKENS: "llm.output_tokens",
+  COST: "llm.cost",
+  TEMPERATURE: "llm.temperature",
+  STATUS: "llm.status",
+  ERROR: "llm.error",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- Extract span attribute keys into `LLM_ATTRS` constants — no more magic strings
- DRY `spans.ts` — shared attributes via `setBaseAttributes()`, no duplication in try/catch
- Wire `recordContent: false` support — skips prompt/completion in spans for privacy
- Make `shutdown()` async — properly awaits SDK flush
- Extract `INSTRUMENTATION_NAME` constant — single source of truth
- Add shields.io badges to README (TypeScript, OTel, Hono, Prometheus, Grafana, Docker, CI, License)

## Test plan
- [x] CI passes
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)