### PR TITLE
fix: Install section in READMEs, demo tsconfig node types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ One-line instrumentation for any LLM service — get traces, metrics, and Grafan
 
 LLM APIs are black boxes — you don't know what they cost, how slow they are, or why they fail. toad-eye gives you full visibility with one line of code.
 
+## Install
+
+```bash
+npm install toad-eye
+```
+
 ## Architecture
 
 ```mermaid

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -18,6 +18,12 @@ One-line instrumentation for any LLM service — get traces, metrics, and Grafan
 
 LLM APIs are black boxes — you don't know what they cost, how slow they are, or why they fail. toad-eye gives you full visibility with one line of code.
 
+## Install
+
+```bash
+npm install toad-eye
+```
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary
- Add "Install" section (`npm install toad-eye`) to both READMEs
- Fix demo tsconfig — add `"types": ["node"]` to resolve `process` type error

## Test plan
- [x] CI passes
- [x] No TS errors in IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)