### PR TITLE
fix: correct repository URL to vola-trebla

### DIFF
--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -19,9 +19,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/albertalov/toad-eye"
+    "url": "https://github.com/vola-trebla/toad-eye"
   },
-  "homepage": "https://github.com/albertalov/toad-eye#readme",
+  "homepage": "https://github.com/vola-trebla/toad-eye#readme",
   "author": "albertalov",
   "keywords": [
     "opentelemetry",


### PR DESCRIPTION
## Summary
- Fix `repository` and `homepage` URLs in package.json: `albertalov/toad-eye` → `vola-trebla/toad-eye`

🤖 Generated with [Claude Code](https://claude.com/claude-code)