### PR TITLE
feat: auto-instrumentation for LLM SDKs

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -7,13 +7,15 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "load": "tsx src/load-test.ts"
+    "load": "tsx src/load-test.ts",
+    "test:auto": "tsx src/test-auto-instrument.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",
-    "toad-eye": "*",
     "dotenv": "^17.3.1",
-    "hono": "^4.12.8"
+    "hono": "^4.12.8",
+    "openai": "^6.32.0",
+    "toad-eye": "*"
   },
   "license": "ISC"
 }

--- a/demo/src/test-auto-instrument.ts
+++ b/demo/src/test-auto-instrument.ts
@@ -1,0 +1,88 @@
+/**
+ * Test script for auto-instrumentation.
+ *
+ * 1. Starts a fake OpenAI-compatible endpoint on :4444
+ * 2. Inits toad-eye with instrument: ['openai']
+ * 3. Makes a real OpenAI SDK call pointed at the fake server
+ * 4. Span should appear in Jaeger (localhost:16686)
+ */
+
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { initObservability, shutdown } from "toad-eye";
+
+// --- 1. Fake OpenAI-compatible server ---
+
+const fakeOpenAI = new Hono();
+
+fakeOpenAI.post("/v1/chat/completions", async (c) => {
+  const body = await c.req.json();
+  return c.json({
+    id: "chatcmpl-test-123",
+    object: "chat.completion",
+    created: Date.now(),
+    model: body.model ?? "gpt-4o",
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: `Mock response for: "${body.messages?.[0]?.content ?? "?"}"`,
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 42,
+      completion_tokens: 18,
+      total_tokens: 60,
+    },
+  });
+});
+
+const server = serve({ fetch: fakeOpenAI.fetch, port: 4444 }, () => {
+  console.log("Fake OpenAI server on http://localhost:4444");
+});
+
+// --- 2. Init toad-eye BEFORE importing OpenAI SDK ---
+
+initObservability({
+  serviceName: "auto-instrument-test",
+  endpoint: "http://localhost:4318",
+  instrument: ["openai"],
+});
+
+console.log("toad-eye initialized with instrument: ['openai']");
+
+// --- 3. Import OpenAI SDK and make a call ---
+
+const { default: OpenAI } = await import("openai");
+
+const client = new OpenAI({
+  apiKey: "fake-key",
+  baseURL: "http://localhost:4444/v1",
+});
+
+console.log("\nMaking 3 OpenAI SDK calls...\n");
+
+for (let i = 1; i <= 3; i++) {
+  const result = await client.chat.completions.create({
+    model: "gpt-4o",
+    messages: [{ role: "user", content: `Test prompt number ${i}` }],
+    temperature: 0.7,
+  });
+  console.log(`Call ${i}: ${result.choices[0]?.message?.content}`);
+}
+
+// --- 4. Cleanup ---
+
+console.log("\nWaiting 6s for metrics export...");
+await new Promise((r) => setTimeout(r, 6000));
+
+await shutdown();
+server.close();
+
+console.log("\nDone! Check:");
+console.log("  Jaeger:      http://localhost:16686");
+console.log("  Prometheus:  http://localhost:9090");
+console.log('  (search for service "auto-instrument-test")');

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/llm-overview.json
     ports:
-      - "3000:3000"
+      - "3100:3000"
     depends_on:
       - prometheus
       - jaeger

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@hono/node-server": "^1.19.11",
         "dotenv": "^17.3.1",
         "hono": "^4.12.8",
+        "openai": "^6.32.0",
         "toad-eye": "*"
       }
     },
@@ -1835,6 +1836,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+      "integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -2163,7 +2185,7 @@
     },
     "packages/instrumentation": {
       "name": "toad-eye",
-      "version": "0.3.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -2173,6 +2195,9 @@
         "@opentelemetry/sdk-metrics": "^2.6.0",
         "@opentelemetry/sdk-node": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.40.0"
+      },
+      "bin": {
+        "toad-eye": "dist/cli.js"
       }
     }
   }

--- a/packages/instrumentation/src/instrumentations/anthropic.ts
+++ b/packages/instrumentation/src/instrumentations/anthropic.ts
@@ -1,0 +1,120 @@
+import { createRequire } from "node:module";
+import { diag } from "@opentelemetry/api";
+import { traceLLMCall } from "../spans.js";
+import type { LLMCallOutput } from "../spans.js";
+import { register } from "./registry.js";
+import type { Instrumentation } from "./types.js";
+
+const require = createRequire(import.meta.url);
+
+let originalCreate: ((...args: unknown[]) => unknown) | null = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let messagesProto: any = null;
+
+function extractPrompt(messages: unknown): string {
+  if (!Array.isArray(messages)) return "";
+  return messages
+    .map((m: { content?: unknown }) => {
+      if (typeof m.content === "string") return m.content;
+      if (Array.isArray(m.content)) {
+        return (m.content as { type?: string; text?: string }[])
+          .filter((b) => b.type === "text")
+          .map((b) => b.text)
+          .join("");
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function extractCompletion(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return (content as { type?: string; text?: string }[])
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("");
+}
+
+const anthropicInstrumentation: Instrumentation = {
+  name: "anthropic",
+
+  enable() {
+    try {
+      require.resolve("@anthropic-ai/sdk");
+    } catch {
+      return false;
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const sdk = require("@anthropic-ai/sdk");
+      const Anthropic = sdk.default ?? sdk;
+
+      // Anthropic SDK exposes Messages class
+      const MessagesClass = Anthropic?.Messages;
+
+      if (!MessagesClass?.prototype?.create) {
+        diag.debug("toad-eye: Anthropic Messages.prototype.create not found");
+        return false;
+      }
+
+      messagesProto = MessagesClass.prototype;
+      originalCreate = messagesProto.create;
+
+      messagesProto.create = function patchedCreate(
+        body: Record<string, unknown>,
+        ...rest: unknown[]
+      ) {
+        // Skip streaming — passthrough
+        if (body?.stream) {
+          return originalCreate!.call(this, body, ...rest);
+        }
+
+        const prompt = extractPrompt(body?.messages);
+        const model = (body?.model as string) ?? "unknown";
+        const temperature = (body?.temperature as number) ?? 1.0;
+
+        return traceLLMCall(
+          { provider: "anthropic", model, prompt, temperature },
+          async (): Promise<LLMCallOutput> => {
+            const response = (await originalCreate!.call(
+              this,
+              body,
+              ...rest,
+            )) as {
+              content?: unknown;
+              usage?: {
+                input_tokens?: number;
+                output_tokens?: number;
+              };
+              model?: string;
+            };
+
+            return {
+              completion: extractCompletion(response?.content),
+              inputTokens: response?.usage?.input_tokens ?? 0,
+              outputTokens: response?.usage?.output_tokens ?? 0,
+              cost: 0,
+            };
+          },
+        );
+      };
+
+      return true;
+    } catch (err) {
+      diag.warn(`toad-eye: failed to patch anthropic: ${err}`);
+      return false;
+    }
+  },
+
+  disable() {
+    if (messagesProto && originalCreate) {
+      messagesProto.create = originalCreate;
+      originalCreate = null;
+      messagesProto = null;
+    }
+  },
+};
+
+register(anthropicInstrumentation);

--- a/packages/instrumentation/src/instrumentations/gemini.ts
+++ b/packages/instrumentation/src/instrumentations/gemini.ts
@@ -1,0 +1,113 @@
+import { createRequire } from "node:module";
+import { diag } from "@opentelemetry/api";
+import { traceLLMCall } from "../spans.js";
+import type { LLMCallOutput } from "../spans.js";
+import { register } from "./registry.js";
+import type { Instrumentation } from "./types.js";
+
+const require = createRequire(import.meta.url);
+
+let originalGenerateContent: ((...args: unknown[]) => unknown) | null = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let modelProto: any = null;
+
+function extractPrompt(request: unknown): string {
+  if (typeof request === "string") return request;
+  if (typeof request === "object" && request !== null) {
+    const req = request as { contents?: unknown };
+    if (Array.isArray(req.contents)) {
+      return (req.contents as { parts?: { text?: string }[] }[])
+        .flatMap((c) => c.parts ?? [])
+        .map((p) => p.text ?? "")
+        .filter(Boolean)
+        .join("\n");
+    }
+  }
+  return "";
+}
+
+const geminiInstrumentation: Instrumentation = {
+  name: "gemini",
+
+  enable() {
+    try {
+      require.resolve("@google/generative-ai");
+    } catch {
+      return false;
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const sdk = require("@google/generative-ai");
+      const GenerativeModel = sdk.GenerativeModel;
+
+      if (!GenerativeModel?.prototype?.generateContent) {
+        diag.debug(
+          "toad-eye: GenerativeModel.prototype.generateContent not found",
+        );
+        return false;
+      }
+
+      modelProto = GenerativeModel.prototype;
+      originalGenerateContent = modelProto.generateContent;
+
+      modelProto.generateContent = function patchedGenerateContent(
+        request: unknown,
+        ...rest: unknown[]
+      ) {
+        const prompt = extractPrompt(request);
+        // `this.model` contains the model name on GenerativeModel instances
+        const model = (this as { model?: string }).model ?? "unknown";
+
+        return traceLLMCall(
+          { provider: "gemini", model, prompt },
+          async (): Promise<LLMCallOutput> => {
+            const result = (await originalGenerateContent!.call(
+              this,
+              request,
+              ...rest,
+            )) as {
+              response?: {
+                text?: () => string;
+                usageMetadata?: {
+                  promptTokenCount?: number;
+                  candidatesTokenCount?: number;
+                };
+              };
+            };
+
+            const response = result?.response;
+            let completion = "";
+            try {
+              completion = response?.text?.() ?? "";
+            } catch {
+              // text() may throw if response is blocked
+            }
+
+            return {
+              completion,
+              inputTokens: response?.usageMetadata?.promptTokenCount ?? 0,
+              outputTokens: response?.usageMetadata?.candidatesTokenCount ?? 0,
+              cost: 0,
+            };
+          },
+        );
+      };
+
+      return true;
+    } catch (err) {
+      diag.warn(`toad-eye: failed to patch gemini: ${err}`);
+      return false;
+    }
+  },
+
+  disable() {
+    if (modelProto && originalGenerateContent) {
+      modelProto.generateContent = originalGenerateContent;
+      originalGenerateContent = null;
+      modelProto = null;
+    }
+  },
+};
+
+register(geminiInstrumentation);

--- a/packages/instrumentation/src/instrumentations/openai.ts
+++ b/packages/instrumentation/src/instrumentations/openai.ts
@@ -1,0 +1,151 @@
+import { createRequire } from "node:module";
+import { diag } from "@opentelemetry/api";
+import { traceLLMCall } from "../spans.js";
+import type { LLMCallOutput } from "../spans.js";
+import { register } from "./registry.js";
+import type { Instrumentation } from "./types.js";
+
+const require = createRequire(import.meta.url);
+
+let originalChatCreate: ((...args: unknown[]) => unknown) | null = null;
+let originalEmbeddingsCreate: ((...args: unknown[]) => unknown) | null = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let chatProto: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let embeddingsProto: any = null;
+
+function extractPrompt(messages: unknown): string {
+  if (!Array.isArray(messages)) return "";
+  return messages
+    .map((m: { content?: unknown }) => {
+      if (typeof m.content === "string") return m.content;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+const openaiInstrumentation: Instrumentation = {
+  name: "openai",
+
+  enable() {
+    try {
+      require.resolve("openai");
+    } catch {
+      return false;
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const sdk = require("openai");
+      const OpenAI = sdk.default ?? sdk;
+
+      // Access resource class prototypes
+      // OpenAI SDK v4+ exposes: OpenAI.Chat.Completions, OpenAI.Embeddings
+      const CompletionsClass = OpenAI?.Chat?.Completions ?? OpenAI?.Completions;
+      const EmbeddingsClass = OpenAI?.Embeddings;
+
+      if (CompletionsClass?.prototype?.create) {
+        chatProto = CompletionsClass.prototype;
+        originalChatCreate = chatProto.create;
+        chatProto.create = function patchedChatCreate(
+          body: Record<string, unknown>,
+          ...rest: unknown[]
+        ) {
+          // Skip streaming — passthrough
+          if (body?.stream) {
+            return originalChatCreate!.call(this, body, ...rest);
+          }
+
+          const prompt = extractPrompt(body?.messages);
+          const model = (body?.model as string) ?? "unknown";
+          const temperature = (body?.temperature as number) ?? 1.0;
+
+          return traceLLMCall(
+            { provider: "openai", model, prompt, temperature },
+            async (): Promise<LLMCallOutput> => {
+              const response = (await originalChatCreate!.call(
+                this,
+                body,
+                ...rest,
+              )) as {
+                choices?: { message?: { content?: string } }[];
+                usage?: {
+                  prompt_tokens?: number;
+                  completion_tokens?: number;
+                };
+                model?: string;
+              };
+
+              return {
+                completion: response?.choices?.[0]?.message?.content ?? "",
+                inputTokens: response?.usage?.prompt_tokens ?? 0,
+                outputTokens: response?.usage?.completion_tokens ?? 0,
+                cost: 0,
+              };
+            },
+          );
+        };
+      }
+
+      if (EmbeddingsClass?.prototype?.create) {
+        embeddingsProto = EmbeddingsClass.prototype;
+        originalEmbeddingsCreate = embeddingsProto.create;
+        embeddingsProto.create = function patchedEmbeddingsCreate(
+          body: Record<string, unknown>,
+          ...rest: unknown[]
+        ) {
+          const input = body?.input;
+          const prompt =
+            typeof input === "string"
+              ? input
+              : Array.isArray(input)
+                ? (input as string[]).join("\n")
+                : "";
+          const model = (body?.model as string) ?? "unknown";
+
+          return traceLLMCall(
+            { provider: "openai", model, prompt },
+            async (): Promise<LLMCallOutput> => {
+              const response = (await originalEmbeddingsCreate!.call(
+                this,
+                body,
+                ...rest,
+              )) as {
+                usage?: { prompt_tokens?: number; total_tokens?: number };
+                model?: string;
+              };
+
+              return {
+                completion: "[embedding]",
+                inputTokens: response?.usage?.prompt_tokens ?? 0,
+                outputTokens: 0,
+                cost: 0,
+              };
+            },
+          );
+        };
+      }
+
+      return !!(originalChatCreate || originalEmbeddingsCreate);
+    } catch (err) {
+      diag.warn(`toad-eye: failed to patch openai: ${err}`);
+      return false;
+    }
+  },
+
+  disable() {
+    if (chatProto && originalChatCreate) {
+      chatProto.create = originalChatCreate;
+      originalChatCreate = null;
+      chatProto = null;
+    }
+    if (embeddingsProto && originalEmbeddingsCreate) {
+      embeddingsProto.create = originalEmbeddingsCreate;
+      originalEmbeddingsCreate = null;
+      embeddingsProto = null;
+    }
+  },
+};
+
+register(openaiInstrumentation);

--- a/packages/instrumentation/src/instrumentations/registry.ts
+++ b/packages/instrumentation/src/instrumentations/registry.ts
@@ -1,0 +1,37 @@
+import { diag } from "@opentelemetry/api";
+import type { LLMProvider } from "../types.js";
+import type { Instrumentation } from "./types.js";
+
+const instrumentations = new Map<LLMProvider, Instrumentation>();
+const active = new Set<LLMProvider>();
+
+export function register(inst: Instrumentation) {
+  instrumentations.set(inst.name, inst);
+}
+
+export function enableAll(providers: readonly LLMProvider[]) {
+  for (const name of providers) {
+    if (active.has(name)) continue;
+
+    const inst = instrumentations.get(name);
+    if (!inst) {
+      diag.warn(`toad-eye: unknown provider "${name}", skipping`);
+      continue;
+    }
+
+    const patched = inst.enable();
+    if (patched) {
+      active.add(name);
+      diag.debug(`toad-eye: auto-instrumented ${name}`);
+    } else {
+      diag.debug(`toad-eye: ${name} SDK not found, skipping`);
+    }
+  }
+}
+
+export function disableAll() {
+  for (const name of active) {
+    instrumentations.get(name)?.disable();
+  }
+  active.clear();
+}

--- a/packages/instrumentation/src/instrumentations/types.ts
+++ b/packages/instrumentation/src/instrumentations/types.ts
@@ -1,0 +1,17 @@
+import type { LLMProvider } from "../types.js";
+
+export interface Instrumentation {
+  readonly name: LLMProvider;
+  /** Try to find and patch the SDK. Returns true if patched, false if SDK not found. */
+  enable(): boolean;
+  /** Restore original methods. */
+  disable(): void;
+}
+
+/** Data extracted from an LLM SDK response */
+export interface ExtractedLLMResponse {
+  readonly completion: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly model: string;
+}

--- a/packages/instrumentation/src/tracer.ts
+++ b/packages/instrumentation/src/tracer.ts
@@ -6,6 +6,12 @@ import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import type { ToadEyeConfig } from "./types.js";
 import { initMetrics } from "./metrics.js";
+import { enableAll, disableAll } from "./instrumentations/registry.js";
+
+// Side-effect imports: register provider instrumentations
+import "./instrumentations/openai.js";
+import "./instrumentations/anthropic.js";
+import "./instrumentations/gemini.js";
 
 const DEFAULT_ENDPOINT = "http://localhost:4318";
 
@@ -47,10 +53,15 @@ export function initObservability(config: ToadEyeConfig) {
   sdk.start();
   currentConfig = config;
   initMetrics();
+
+  if (config.instrument?.length) {
+    enableAll(config.instrument);
+  }
 }
 
 export async function shutdown() {
   if (!sdk) return;
+  disableAll();
   await sdk.shutdown();
   sdk = null;
   currentConfig = null;

--- a/packages/instrumentation/src/types.ts
+++ b/packages/instrumentation/src/types.ts
@@ -73,4 +73,5 @@ export interface ToadEyeConfig {
   readonly serviceName: string;
   readonly endpoint?: string | undefined;
   readonly recordContent?: boolean | undefined;
+  readonly instrument?: readonly LLMProvider[] | undefined;
 }


### PR DESCRIPTION
## Summary
- Add `instrument` option to `initObservability()` for automatic LLM SDK patching
- Supported SDKs: OpenAI (`chat.completions.create`, `embeddings.create`), Anthropic (`messages.create`), Google GenAI (`generateContent`)
- Pluggable registry pattern — each provider in separate file under `instrumentations/`
- Zero overhead when SDK not installed (detected via `createRequire`)
- Streaming calls pass through unpatched (future scope)
- Includes test script with fake OpenAI server (`demo/src/test-auto-instrument.ts`)
- Fix: Grafana port changed from 3000 to 3100 to match README

## Test plan
- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run test:auto --workspace=demo` — 3 traces visible in Jaeger
- [ ] Verify Anthropic SDK patching (requires `@anthropic-ai/sdk` installed)
- [ ] Verify Gemini SDK patching (requires `@google/generative-ai` installed)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)