### PR TITLE
feat: rewrite README — Quick Start in 5 lines (story #1.3)

### DIFF
--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -1,126 +1,171 @@
 # toad-eye 🐸👁️
 
-![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
-![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-000000?logo=opentelemetry&logoColor=white)
-![Hono](https://img.shields.io/badge/Hono-E36002?logo=hono&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?logo=prometheus&logoColor=white)
-![Grafana](https://img.shields.io/badge/Grafana-F46800?logo=grafana&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
-![npm](https://img.shields.io/npm/v/toad-eye?color=CB3837&logo=npm&logoColor=white)
-![CI](https://github.com/vola-trebla/toad-eye/actions/workflows/ci.yml/badge.svg)
-![License](https://img.shields.io/badge/License-ISC-blue)
+[![npm version](https://img.shields.io/npm/v/toad-eye?color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/toad-eye)
+[![npm downloads](https://img.shields.io/npm/dm/toad-eye?color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/toad-eye)
+[![CI](https://github.com/vola-trebla/toad-eye/actions/workflows/ci.yml/badge.svg)](https://github.com/vola-trebla/toad-eye/actions)
+[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
-OpenTelemetry-based observability toolkit for LLM systems.
+**Full observability for LLM services — traces, metrics, and Grafana dashboards in one line of code.**
 
-One-line instrumentation for any LLM service — get traces, metrics, and Grafana dashboards out of the box.
+> LLM APIs are black boxes. You don't know what they cost, how slow they are, or why they fail.
+> toad-eye gives you complete visibility with zero manual instrumentation.
 
-## Why toad-eye?
+<!-- TODO: record GIF — terminal: npx toad-eye init → up → demo → Grafana with live data -->
+<!-- ![toad-eye demo](https://raw.githubusercontent.com/vola-trebla/toad-eye/main/demo/toad-eye-demo.gif) -->
 
-LLM APIs are black boxes — you don't know what they cost, how slow they are, or why they fail. toad-eye gives you full visibility with one line of code.
+---
 
-## Install
+## Quick Start
 
 ```bash
 npm install toad-eye
+npx toad-eye init   # scaffold observability stack configs
+npx toad-eye up     # start OTel Collector + Prometheus + Jaeger + Grafana
 ```
-
-## Architecture
-
-```
-Your LLM service
-       │
-       ▼
-toad-eye
-       │
-       ▼ OTLP/HTTP
-OTel Collector
-       ├──▶ Prometheus ──▶ Grafana
-       └──▶ Jaeger
-```
-
-## Quick start
-
-```bash
-npm install
-cd infra && docker compose up -d   # start observability stack
-npm run demo                        # start mock LLM service
-npm run load --workspace=demo       # send test traffic
-```
-
-| Service        | URL                                       |
-| -------------- | ----------------------------------------- |
-| Grafana        | [localhost:3000](http://localhost:3000)   |
-| Jaeger UI      | [localhost:16686](http://localhost:16686) |
-| Prometheus     | [localhost:9090](http://localhost:9090)   |
-| OTel Collector | [localhost:4318](http://localhost:4318)   |
-
-## Usage
 
 ```typescript
-import { initObservability, traceLLMCall } from "toad-eye";
+import { initObservability } from "toad-eye";
 
-// one-line init
 initObservability({
-  serviceName: "my-llm-service",
-  endpoint: "http://localhost:4318",
+  serviceName: "my-app",
+  instrument: ["anthropic", "openai"],
 });
-
-// wrap any LLM call
-const result = await traceLLMCall(
-  { provider: "anthropic", model: "claude-sonnet-4-20250514", prompt: "hello" },
-  () => callYourLLM(),
-);
+// Every LLM call is now automatically traced. Open http://localhost:3100
 ```
 
-> **Privacy mode:** pass `recordContent: false` to `initObservability()` to stop recording prompt/completion text in spans. Useful in production when prompts contain sensitive data.
+That's it. **No wrappers. No manual spans.** All your Anthropic and OpenAI calls are traced automatically.
 
-## What it tracks
+---
 
-### Metrics
-
-| Metric                 | Type      | Description                            |
-| ---------------------- | --------- | -------------------------------------- |
-| `llm.request.duration` | Histogram | Request latency in milliseconds        |
-| `llm.request.cost`     | Histogram | Cost per request in USD                |
-| `llm.tokens`           | Counter   | Total tokens consumed (input + output) |
-| `llm.requests`         | Counter   | Total requests made                    |
-| `llm.errors`           | Counter   | Total failed requests                  |
-
-All metrics are labeled with `provider` and `model` for filtering and grouping.
-
-### Span attributes
-
-| Attribute           | Type   | Description                     |
-| ------------------- | ------ | ------------------------------- |
-| `llm.provider`      | string | `anthropic`, `gemini`, `openai` |
-| `llm.model`         | string | Model identifier                |
-| `llm.prompt`        | string | Prompt sent to the LLM          |
-| `llm.completion`    | string | Response from the LLM           |
-| `llm.input_tokens`  | number | Tokens in the prompt            |
-| `llm.output_tokens` | number | Tokens in the completion        |
-| `llm.cost`          | number | Cost in USD                     |
-| `llm.temperature`   | number | Temperature parameter           |
-| `llm.status`        | string | `success` or `error`            |
-| `llm.error`         | string | Error message (if failed)       |
-
-## Grafana dashboard
+## What you get
 
 ![toad-eye Grafana dashboard](https://raw.githubusercontent.com/vola-trebla/toad-eye/main/demo/grafana-dashboard.png)
 
-## Jaeger traces
+| Feature                  | Details                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| **Auto-instrumentation** | Patches Anthropic, OpenAI, Gemini SDKs — no code changes needed                   |
+| **5 Grafana dashboards** | Overview · Cost Breakdown · Latency Analysis · Model Comparison · Error Drilldown |
+| **Cost tracking**        | Per-request USD cost, hourly/daily totals, top models by spend                    |
+| **Cost alerts**          | Threshold alerts via Telegram, Slack, email, or webhook                           |
+| **Distributed traces**   | Full spans in Jaeger with prompts, completions, tokens                            |
+| **One-command stack**    | `npx toad-eye up` starts the entire observability stack                           |
 
-![toad-eye Jaeger traces](https://raw.githubusercontent.com/vola-trebla/toad-eye/main/demo/jaeger-traces.png)
+---
 
-## Project structure
+## Observability stack
 
+```mermaid
+flowchart LR
+    app["Your LLM App\n(toad-eye SDK)"]
+    col["OTel Collector\n:4318"]
+    prom["Prometheus\n:9090"]
+    jaeger["Jaeger\n:16686"]
+    grafana["Grafana\n:3100"]
+
+    app -->|OTLP/HTTP| col
+    col -->|metrics| prom
+    col -->|traces| jaeger
+    prom --> grafana
+    jaeger --> grafana
 ```
-packages/instrumentation/   — NPM package (toad-eye)
-demo/                       — mock LLM service for testing
-infra/                      — docker-compose stack (OTel + Prometheus + Jaeger + Grafana)
+
+| Service    | URL                                   |
+| ---------- | ------------------------------------- |
+| Grafana    | http://localhost:3100 (admin / admin) |
+| Jaeger     | http://localhost:16686                |
+| Prometheus | http://localhost:9090                 |
+
+---
+
+## Metrics
+
+| Metric                 | Type      | Description                                 |
+| ---------------------- | --------- | ------------------------------------------- |
+| `llm.request.duration` | Histogram | Request latency (ms), by provider + model   |
+| `llm.request.cost`     | Histogram | Cost per request (USD), by provider + model |
+| `llm.tokens`           | Counter   | Total tokens consumed (input + output)      |
+| `llm.requests`         | Counter   | Total requests made                         |
+| `llm.errors`           | Counter   | Total failed requests                       |
+
+---
+
+## Advanced
+
+### Manual tracing
+
+If you need to trace a provider not yet auto-instrumented:
+
+```typescript
+import { traceLLMCall } from "toad-eye";
+
+const result = await traceLLMCall(
+  { provider: "anthropic", model: "claude-sonnet-4-20250514", prompt: input, temperature: 0.7 },
+  () => client.messages.create({ ... }),
+  (res) => ({
+    completion: res.content[0].text,
+    inputTokens: res.usage.input_tokens,
+    outputTokens: res.usage.output_tokens,
+    cost: calcCost(res.usage),
+  }),
+);
 ```
 
-## Tech stack
+### Privacy mode
 
-- TypeScript, OpenTelemetry SDK 2.x, OTLP exporters
-- Hono (demo server)
-- Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector)
+Stop recording prompt/completion content in spans — useful in production:
+
+```typescript
+initObservability({ serviceName: "my-app", recordContent: false });
+```
+
+### Cost alerts
+
+Fire alerts when spend crosses a threshold:
+
+```typescript
+import { AlertManager } from "toad-eye";
+
+const alerts = new AlertManager({
+  prometheusUrl: "http://localhost:9090",
+  channels: {
+    telegram: {
+      type: "telegram",
+      token: process.env.TG_TOKEN!,
+      chatId: process.env.TG_CHAT!,
+    },
+  },
+  alerts: [
+    {
+      name: "cost_spike",
+      metric: "llm.request.cost",
+      condition: "sum_1h > 10",
+      channels: ["telegram"],
+    },
+  ],
+});
+
+alerts.start();
+```
+
+Or configure via YAML — see [`infra/toad-eye/alerts.yml`](https://github.com/vola-trebla/toad-eye/blob/main/infra/toad-eye/alerts.yml).
+
+### Custom OTLP endpoint
+
+```typescript
+initObservability({
+  serviceName: "my-app",
+  endpoint: "http://your-collector:4318",
+});
+```
+
+---
+
+## CLI reference
+
+```bash
+npx toad-eye init     # scaffold infra/toad-eye/ configs into your project
+npx toad-eye up       # docker compose up -d (OTel + Prometheus + Jaeger + Grafana)
+npx toad-eye down     # docker compose down
+npx toad-eye status   # show running services
+npx toad-eye demo     # start built-in demo with mock LLM traffic
+```


### PR DESCRIPTION
## Summary

- Quick Start: 3 bash команды + 2 строки кода → открой Grafana
- Auto-instrumentation как главный hook — no wrappers, no manual spans
- Features table: dashboards, cost alerts, traces, one-command stack
- Mermaid architecture diagram вместо ASCII
- Advanced section: manual tracing, privacy mode, cost alerts, custom endpoint, CLI reference
- Badges: npm version + downloads + CI + license
- GIF placeholder (TODO: записать terminal demo)

## AC из issue

- [x] Quick Start — максимум 5 строк до первого результата
- [x] Badges: npm version, downloads, CI, license
- [ ] GIF recorded — нужно записать руками после запуска стека
- [ ] Grafana screenshot с реальными данными — после запуска

Closes #29