### PR TITLE
feat: migrate to OTel GenAI semantic conventions

### DIFF
--- a/infra/grafana/dashboards/cost-breakdown.json
+++ b/infra/grafana/dashboards/cost-breakdown.json
@@ -13,7 +13,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -38,7 +38,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1d]))",
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1d]))",
           "refId": "A"
         }
       ],
@@ -63,7 +63,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1d])) * 86400 * 30",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1d])) * 86400 * 30",
           "refId": "A"
         }
       ],
@@ -88,8 +88,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -113,8 +113,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -138,7 +138,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) / sum(rate(llm_request_cost_USD_count{provider=~\"$provider\", model=~\"$model\"}[5m]))",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) / sum(rate(gen_ai_client_request_cost_USD_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m]))",
           "legendFormat": "avg cost/request",
           "refId": "A"
         }
@@ -158,7 +158,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1h]))",
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1h]))",
           "legendFormat": "hourly cost",
           "refId": "A"
         }
@@ -181,7 +181,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -191,7 +191,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/infra/grafana/dashboards/error-drilldown.json
+++ b/infra/grafana/dashboards/error-drilldown.json
@@ -13,7 +13,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -38,7 +38,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}) / sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}) * 100",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) / sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) * 100",
           "refId": "A"
         }
       ],
@@ -63,7 +63,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1h]))",
+          "expr": "sum(increase(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1h]))",
           "refId": "A"
         }
       ],
@@ -88,8 +88,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -108,8 +108,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -128,12 +128,12 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) * 60",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) * 60",
           "legendFormat": "errors/min",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1m])) - sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m]))) * 60",
+          "expr": "(sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) - sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m]))) * 60",
           "legendFormat": "success/min",
           "refId": "B"
         }
@@ -161,7 +161,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -171,7 +171,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/infra/grafana/dashboards/latency-analysis.json
+++ b/infra/grafana/dashboards/latency-analysis.json
@@ -13,18 +13,18 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p50 {{ model }}",
+          "expr": "histogram_quantile(0.50, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p50 {{ gen_ai_request_model }}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p95 {{ model }}",
+          "expr": "histogram_quantile(0.95, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p95 {{ gen_ai_request_model }}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p99 {{ model }}",
+          "expr": "histogram_quantile(0.99, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p99 {{ gen_ai_request_model }}",
           "refId": "C"
         }
       ],
@@ -43,7 +43,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le)",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le)",
           "legendFormat": "{{ le }}",
           "refId": "A",
           "format": "heatmap"
@@ -64,8 +64,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_duration_milliseconds_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_request_duration_milliseconds_count{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model)",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_operation_duration_milliseconds_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model)",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -84,8 +84,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, provider))",
-          "legendFormat": "p99 {{ provider }}",
+          "expr": "histogram_quantile(0.99, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_provider_name))",
+          "legendFormat": "p99 {{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -107,7 +107,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -117,7 +117,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/infra/grafana/dashboards/llm-overview.json
+++ b/infra/grafana/dashboards/llm-overview.json
@@ -13,7 +13,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -38,7 +38,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}) / sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}) * 100",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) / sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) * 100",
           "refId": "A"
         }
       ],
@@ -63,7 +63,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_duration_milliseconds_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) / sum(rate(llm_request_duration_milliseconds_count{provider=~\"$provider\", model=~\"$model\"}[5m]))",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) / sum(rate(gen_ai_client_operation_duration_milliseconds_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -88,7 +88,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -113,8 +113,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -133,8 +133,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -154,12 +154,12 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         }
@@ -179,8 +179,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -199,7 +199,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_tokens_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_token_usage_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -224,7 +224,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -249,7 +249,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -277,7 +277,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -287,7 +287,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/infra/grafana/dashboards/model-comparison.json
+++ b/infra/grafana/dashboards/model-comparison.json
@@ -13,8 +13,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p95 {{ model }}",
+          "expr": "histogram_quantile(0.95, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p95 {{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -33,8 +33,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_request_cost_USD_count{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model)",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_request_cost_USD_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model)",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -53,8 +53,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) * 100",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) * 100",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -73,8 +73,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -93,8 +93,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_tokens_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model)",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_token_usage_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model)",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -116,7 +116,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -126,7 +126,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -19,4 +19,9 @@ export type {
   SpanStatus,
   MetricName,
 } from "./types.js";
-export { LLM_METRICS, LLM_ATTRS } from "./types.js";
+export {
+  GEN_AI_METRICS,
+  GEN_AI_ATTRS,
+  LLM_METRICS,
+  LLM_ATTRS,
+} from "./types.js";

--- a/packages/instrumentation/src/metrics.ts
+++ b/packages/instrumentation/src/metrics.ts
@@ -1,40 +1,43 @@
 import { metrics } from "@opentelemetry/api";
 import type { Counter, Histogram } from "@opentelemetry/api";
-import { LLM_METRICS, INSTRUMENTATION_NAME } from "./types.js";
+import { GEN_AI_METRICS, INSTRUMENTATION_NAME } from "./types.js";
 
 let requestDuration: Histogram;
 let requestCost: Histogram;
-let tokensTotal: Counter;
+let tokenUsage: Counter;
 let requestsTotal: Counter;
 let errorsTotal: Counter;
 
 let initialized = false;
+
+const LABEL_PROVIDER = "gen_ai.provider.name";
+const LABEL_MODEL = "gen_ai.request.model";
 
 export function initMetrics() {
   if (initialized) return;
 
   const meter = metrics.getMeter(INSTRUMENTATION_NAME);
 
-  requestDuration = meter.createHistogram(LLM_METRICS.REQUEST_DURATION, {
-    description: "LLM request duration in milliseconds",
+  requestDuration = meter.createHistogram(GEN_AI_METRICS.REQUEST_DURATION, {
+    description: "GenAI operation duration in milliseconds",
     unit: "ms",
   });
 
-  requestCost = meter.createHistogram(LLM_METRICS.REQUEST_COST, {
-    description: "LLM request cost in USD",
+  requestCost = meter.createHistogram(GEN_AI_METRICS.REQUEST_COST, {
+    description: "GenAI request cost in USD",
     unit: "USD",
   });
 
-  tokensTotal = meter.createCounter(LLM_METRICS.TOKENS, {
+  tokenUsage = meter.createCounter(GEN_AI_METRICS.TOKEN_USAGE, {
     description: "Total tokens consumed",
   });
 
-  requestsTotal = meter.createCounter(LLM_METRICS.REQUESTS, {
-    description: "Total LLM requests",
+  requestsTotal = meter.createCounter(GEN_AI_METRICS.REQUESTS, {
+    description: "Total GenAI requests",
   });
 
-  errorsTotal = meter.createCounter(LLM_METRICS.ERRORS, {
-    description: "Total failed LLM requests",
+  errorsTotal = meter.createCounter(GEN_AI_METRICS.ERRORS, {
+    description: "Total failed GenAI requests",
   });
 
   initialized = true;
@@ -45,7 +48,10 @@ export function recordRequestDuration(
   provider: string,
   model: string,
 ) {
-  requestDuration.record(ms, { provider, model });
+  requestDuration.record(ms, {
+    [LABEL_PROVIDER]: provider,
+    [LABEL_MODEL]: model,
+  });
 }
 
 export function recordRequestCost(
@@ -53,17 +59,29 @@ export function recordRequestCost(
   provider: string,
   model: string,
 ) {
-  requestCost.record(usd, { provider, model });
+  requestCost.record(usd, {
+    [LABEL_PROVIDER]: provider,
+    [LABEL_MODEL]: model,
+  });
 }
 
 export function recordTokens(count: number, provider: string, model: string) {
-  tokensTotal.add(count, { provider, model });
+  tokenUsage.add(count, {
+    [LABEL_PROVIDER]: provider,
+    [LABEL_MODEL]: model,
+  });
 }
 
 export function recordRequest(provider: string, model: string) {
-  requestsTotal.add(1, { provider, model });
+  requestsTotal.add(1, {
+    [LABEL_PROVIDER]: provider,
+    [LABEL_MODEL]: model,
+  });
 }
 
 export function recordError(provider: string, model: string) {
-  errorsTotal.add(1, { provider, model });
+  errorsTotal.add(1, {
+    [LABEL_PROVIDER]: provider,
+    [LABEL_MODEL]: model,
+  });
 }

--- a/packages/instrumentation/src/spans.ts
+++ b/packages/instrumentation/src/spans.ts
@@ -1,6 +1,6 @@
 import { trace, type Span, SpanStatusCode } from "@opentelemetry/api";
 import type { LLMSpanAttributes } from "./types.js";
-import { LLM_ATTRS, INSTRUMENTATION_NAME } from "./types.js";
+import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types.js";
 import {
   recordRequestDuration,
   recordRequestCost,
@@ -34,10 +34,13 @@ function shouldRecordContent() {
 
 function setBaseAttributes(span: Span, input: LLMCallInput) {
   span.setAttributes({
-    [LLM_ATTRS.PROVIDER]: input.provider,
-    [LLM_ATTRS.MODEL]: input.model,
-    [LLM_ATTRS.TEMPERATURE]: input.temperature ?? 1.0,
-    ...(shouldRecordContent() && { [LLM_ATTRS.PROMPT]: input.prompt }),
+    [GEN_AI_ATTRS.PROVIDER]: input.provider,
+    [GEN_AI_ATTRS.REQUEST_MODEL]: input.model,
+    [GEN_AI_ATTRS.TEMPERATURE]: input.temperature ?? 1.0,
+    [GEN_AI_ATTRS.OPERATION]: "chat",
+    ...(shouldRecordContent() && {
+      [GEN_AI_ATTRS.PROMPT]: input.prompt,
+    }),
   });
 }
 
@@ -46,7 +49,7 @@ export async function traceLLMCall(
   fn: () => Promise<LLMCallOutput>,
 ): Promise<LLMCallOutput> {
   return tracer.startActiveSpan(
-    `llm.${input.provider}.${input.model}`,
+    `gen_ai.${input.provider}.${input.model}`,
     async (span) => {
       const start = performance.now();
       setBaseAttributes(span, input);
@@ -57,12 +60,14 @@ export async function traceLLMCall(
 
         span.setAttributes({
           ...(shouldRecordContent() && {
-            [LLM_ATTRS.COMPLETION]: output.completion,
+            [GEN_AI_ATTRS.COMPLETION]: output.completion,
           }),
-          [LLM_ATTRS.INPUT_TOKENS]: output.inputTokens,
-          [LLM_ATTRS.OUTPUT_TOKENS]: output.outputTokens,
-          [LLM_ATTRS.COST]: output.cost,
-          [LLM_ATTRS.STATUS]: "success",
+          [GEN_AI_ATTRS.RESPONSE_MODEL]: input.model,
+          [GEN_AI_ATTRS.INPUT_TOKENS]: output.inputTokens,
+          [GEN_AI_ATTRS.OUTPUT_TOKENS]: output.outputTokens,
+          [GEN_AI_ATTRS.COST]: output.cost,
+          [GEN_AI_ATTRS.STATUS]: "success",
+          [GEN_AI_ATTRS.FINISH_REASONS]: ["stop"],
         });
         span.setStatus({ code: SpanStatusCode.OK });
 
@@ -81,12 +86,11 @@ export async function traceLLMCall(
         const message = error instanceof Error ? error.message : String(error);
 
         span.setAttributes({
-          [LLM_ATTRS.COMPLETION]: "",
-          [LLM_ATTRS.INPUT_TOKENS]: 0,
-          [LLM_ATTRS.OUTPUT_TOKENS]: 0,
-          [LLM_ATTRS.COST]: 0,
-          [LLM_ATTRS.STATUS]: "error",
-          [LLM_ATTRS.ERROR]: message,
+          [GEN_AI_ATTRS.INPUT_TOKENS]: 0,
+          [GEN_AI_ATTRS.OUTPUT_TOKENS]: 0,
+          [GEN_AI_ATTRS.COST]: 0,
+          [GEN_AI_ATTRS.STATUS]: "error",
+          [GEN_AI_ATTRS.ERROR]: message,
         });
         span.setStatus({ code: SpanStatusCode.ERROR, message });
 

--- a/packages/instrumentation/src/types.ts
+++ b/packages/instrumentation/src/types.ts
@@ -1,7 +1,8 @@
 export const INSTRUMENTATION_NAME = "toad-eye";
 
 /**
- * LLM providers supported by toad-eye
+ * LLM providers supported by toad-eye.
+ * Values follow OTel GenAI semconv `gen_ai.provider.name`.
  */
 export type LLMProvider = "anthropic" | "gemini" | "openai";
 
@@ -30,44 +31,70 @@ export interface LLMSpanAttributes {
 /**
  * Metric names exported to Prometheus.
  *
- * Naming convention follows OpenTelemetry semantic conventions:
- * - dots as separators: "llm.request.duration"
- * - Prometheus auto-converts dots to underscores: llm_request_duration
- * - Prometheus adds _total suffix to counters automatically — do NOT include it in the name
+ * Naming follows OTel GenAI semantic conventions where possible:
+ * - `gen_ai.client.*` prefix for client-side metrics
+ * - Prometheus auto-converts dots to underscores
+ * - Prometheus adds _total suffix to counters automatically
  */
+export const GEN_AI_METRICS = {
+  REQUEST_DURATION: "gen_ai.client.operation.duration",
+  TOKEN_USAGE: "gen_ai.client.token.usage",
+  REQUEST_COST: "gen_ai.client.request.cost",
+  REQUESTS: "gen_ai.client.requests",
+  ERRORS: "gen_ai.client.errors",
+} as const;
+
+/** @deprecated Use GEN_AI_METRICS instead. Kept for backward compatibility. */
 export const LLM_METRICS = {
-  REQUEST_DURATION: "llm.request.duration",
-  REQUEST_COST: "llm.request.cost",
-  TOKENS: "llm.tokens",
-  REQUESTS: "llm.requests",
-  ERRORS: "llm.errors",
+  REQUEST_DURATION: GEN_AI_METRICS.REQUEST_DURATION,
+  REQUEST_COST: GEN_AI_METRICS.REQUEST_COST,
+  TOKENS: GEN_AI_METRICS.TOKEN_USAGE,
+  REQUESTS: GEN_AI_METRICS.REQUESTS,
+  ERRORS: GEN_AI_METRICS.ERRORS,
 } as const;
 
 /**
- * Span attribute keys attached to every LLM span.
- * Using constants prevents typos and enables rename-refactoring.
+ * Span attribute keys following OTel GenAI semantic conventions.
+ * See: https://opentelemetry.io/docs/specs/semconv/gen-ai/
  */
+export const GEN_AI_ATTRS = {
+  PROVIDER: "gen_ai.provider.name",
+  REQUEST_MODEL: "gen_ai.request.model",
+  RESPONSE_MODEL: "gen_ai.response.model",
+  INPUT_TOKENS: "gen_ai.usage.input_tokens",
+  OUTPUT_TOKENS: "gen_ai.usage.output_tokens",
+  TEMPERATURE: "gen_ai.request.temperature",
+  OPERATION: "gen_ai.operation.name",
+  FINISH_REASONS: "gen_ai.response.finish_reasons",
+  // Not in OTel semconv yet — toad-eye extensions
+  PROMPT: "gen_ai.toad_eye.prompt",
+  COMPLETION: "gen_ai.toad_eye.completion",
+  COST: "gen_ai.toad_eye.cost",
+  STATUS: "gen_ai.toad_eye.status",
+  ERROR: "error.type",
+} as const;
+
+/** @deprecated Use GEN_AI_ATTRS instead. Kept for backward compatibility. */
 export const LLM_ATTRS = {
-  PROVIDER: "llm.provider",
-  MODEL: "llm.model",
-  PROMPT: "llm.prompt",
-  COMPLETION: "llm.completion",
-  INPUT_TOKENS: "llm.input_tokens",
-  OUTPUT_TOKENS: "llm.output_tokens",
-  COST: "llm.cost",
-  TEMPERATURE: "llm.temperature",
-  STATUS: "llm.status",
-  ERROR: "llm.error",
+  PROVIDER: GEN_AI_ATTRS.PROVIDER,
+  MODEL: GEN_AI_ATTRS.REQUEST_MODEL,
+  PROMPT: GEN_AI_ATTRS.PROMPT,
+  COMPLETION: GEN_AI_ATTRS.COMPLETION,
+  INPUT_TOKENS: GEN_AI_ATTRS.INPUT_TOKENS,
+  OUTPUT_TOKENS: GEN_AI_ATTRS.OUTPUT_TOKENS,
+  COST: GEN_AI_ATTRS.COST,
+  TEMPERATURE: GEN_AI_ATTRS.TEMPERATURE,
+  STATUS: GEN_AI_ATTRS.STATUS,
+  ERROR: GEN_AI_ATTRS.ERROR,
 } as const;
 
 /**
- * Type-safe metric name — only values from LLM_METRICS are allowed
+ * Type-safe metric name
  */
-export type MetricName = (typeof LLM_METRICS)[keyof typeof LLM_METRICS];
+export type MetricName = (typeof GEN_AI_METRICS)[keyof typeof GEN_AI_METRICS];
 
 /**
  * Configuration for initObservability().
- * This is what the user passes when connecting toad-eye to their service.
  */
 export interface ToadEyeConfig {
   readonly serviceName: string;

--- a/packages/instrumentation/templates/grafana/dashboards/cost-breakdown.json
+++ b/packages/instrumentation/templates/grafana/dashboards/cost-breakdown.json
@@ -13,7 +13,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -38,7 +38,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1d]))",
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1d]))",
           "refId": "A"
         }
       ],
@@ -63,7 +63,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1d])) * 86400 * 30",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1d])) * 86400 * 30",
           "refId": "A"
         }
       ],
@@ -88,8 +88,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -113,8 +113,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -138,7 +138,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) / sum(rate(llm_request_cost_USD_count{provider=~\"$provider\", model=~\"$model\"}[5m]))",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) / sum(rate(gen_ai_client_request_cost_USD_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m]))",
           "legendFormat": "avg cost/request",
           "refId": "A"
         }
@@ -158,7 +158,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1h]))",
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1h]))",
           "legendFormat": "hourly cost",
           "refId": "A"
         }
@@ -181,7 +181,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -191,7 +191,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/packages/instrumentation/templates/grafana/dashboards/error-drilldown.json
+++ b/packages/instrumentation/templates/grafana/dashboards/error-drilldown.json
@@ -13,7 +13,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -38,7 +38,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}) / sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}) * 100",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) / sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) * 100",
           "refId": "A"
         }
       ],
@@ -63,7 +63,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1h]))",
+          "expr": "sum(increase(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1h]))",
           "refId": "A"
         }
       ],
@@ -88,8 +88,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -108,8 +108,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -128,12 +128,12 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) * 60",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) * 60",
           "legendFormat": "errors/min",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1m])) - sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m]))) * 60",
+          "expr": "(sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) - sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m]))) * 60",
           "legendFormat": "success/min",
           "refId": "B"
         }
@@ -161,7 +161,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -171,7 +171,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/packages/instrumentation/templates/grafana/dashboards/latency-analysis.json
+++ b/packages/instrumentation/templates/grafana/dashboards/latency-analysis.json
@@ -13,18 +13,18 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p50 {{ model }}",
+          "expr": "histogram_quantile(0.50, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p50 {{ gen_ai_request_model }}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p95 {{ model }}",
+          "expr": "histogram_quantile(0.95, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p95 {{ gen_ai_request_model }}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p99 {{ model }}",
+          "expr": "histogram_quantile(0.99, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p99 {{ gen_ai_request_model }}",
           "refId": "C"
         }
       ],
@@ -43,7 +43,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le)",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le)",
           "legendFormat": "{{ le }}",
           "refId": "A",
           "format": "heatmap"
@@ -64,8 +64,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_duration_milliseconds_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_request_duration_milliseconds_count{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model)",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_operation_duration_milliseconds_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model)",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -84,8 +84,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, provider))",
-          "legendFormat": "p99 {{ provider }}",
+          "expr": "histogram_quantile(0.99, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_provider_name))",
+          "legendFormat": "p99 {{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -107,7 +107,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -117,7 +117,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/packages/instrumentation/templates/grafana/dashboards/llm-overview.json
+++ b/packages/instrumentation/templates/grafana/dashboards/llm-overview.json
@@ -13,7 +13,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -38,7 +38,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}) / sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}) * 100",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) / sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}) * 100",
           "refId": "A"
         }
       ],
@@ -63,7 +63,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_duration_milliseconds_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) / sum(rate(llm_request_duration_milliseconds_count{provider=~\"$provider\", model=~\"$model\"}[5m]))",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) / sum(rate(gen_ai_client_operation_duration_milliseconds_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m]))",
           "refId": "A"
         }
       ],
@@ -88,7 +88,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -113,8 +113,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -133,8 +133,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -154,12 +154,12 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         }
@@ -179,8 +179,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -199,7 +199,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_tokens_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_token_usage_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -224,7 +224,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_requests_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -249,7 +249,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_errors_total{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -277,7 +277,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -287,7 +287,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },

--- a/packages/instrumentation/templates/grafana/dashboards/model-comparison.json
+++ b/packages/instrumentation/templates/grafana/dashboards/model-comparison.json
@@ -13,8 +13,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_milliseconds_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])) by (le, model))",
-          "legendFormat": "p95 {{ model }}",
+          "expr": "histogram_quantile(0.95, sum(rate(gen_ai_client_operation_duration_milliseconds_bucket{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (le, gen_ai_request_model))",
+          "legendFormat": "p95 {{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -33,8 +33,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_request_cost_USD_count{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model)",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_request_cost_USD_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model)",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -53,8 +53,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_errors_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) * 100",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) * 100",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -73,8 +73,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -93,8 +93,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_tokens_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model) / sum(rate(llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[5m])) by (model)",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_token_usage_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model) / sum(rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) by (gen_ai_request_model)",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -116,7 +116,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -126,7 +126,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },


### PR DESCRIPTION
## Summary
- Span attributes migrated from `llm.*` to `gen_ai.*` per OTel GenAI semconv
- Metric names migrated from `llm.*` to `gen_ai.client.*`
- Metric labels: `provider` → `gen_ai.provider.name`, `model` → `gen_ai.request.model`
- `LLM_ATTRS` and `LLM_METRICS` kept as deprecated aliases for backward compatibility
- All 10 Grafana dashboards updated (infra + templates)

## Test plan
- [x] Build passes
- [x] Typecheck passes
- [ ] `npm run demo` + load test → verify Grafana shows data with new metric names

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)