### PR TITLE
feat: cost attribution engine with built-in pricing

### DIFF
--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -11,6 +11,8 @@ export type {
   FiredAlert,
 } from "./alerts/index.js";
 export { traceLLMCall } from "./spans.js";
+export { calculateCost, setCustomPricing, getModelPricing } from "./pricing.js";
+export type { ModelPricing } from "./pricing.js";
 export type { LLMCallInput, LLMCallOutput } from "./spans.js";
 export type {
   ToadEyeConfig,

--- a/packages/instrumentation/src/instrumentations/anthropic.ts
+++ b/packages/instrumentation/src/instrumentations/anthropic.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { diag } from "@opentelemetry/api";
 import { traceLLMCall } from "../spans.js";
 import type { LLMCallOutput } from "../spans.js";
+import { calculateCost } from "../pricing.js";
 import { register } from "./registry.js";
 import type { Instrumentation } from "./types.js";
 
@@ -95,7 +96,11 @@ const anthropicInstrumentation: Instrumentation = {
               completion: extractCompletion(response?.content),
               inputTokens: response?.usage?.input_tokens ?? 0,
               outputTokens: response?.usage?.output_tokens ?? 0,
-              cost: 0,
+              cost: calculateCost(
+                response?.model ?? model,
+                response?.usage?.input_tokens ?? 0,
+                response?.usage?.output_tokens ?? 0,
+              ),
             };
           },
         );

--- a/packages/instrumentation/src/instrumentations/gemini.ts
+++ b/packages/instrumentation/src/instrumentations/gemini.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { diag } from "@opentelemetry/api";
 import { traceLLMCall } from "../spans.js";
 import type { LLMCallOutput } from "../spans.js";
+import { calculateCost } from "../pricing.js";
 import { register } from "./registry.js";
 import type { Instrumentation } from "./types.js";
 
@@ -88,7 +89,11 @@ const geminiInstrumentation: Instrumentation = {
               completion,
               inputTokens: response?.usageMetadata?.promptTokenCount ?? 0,
               outputTokens: response?.usageMetadata?.candidatesTokenCount ?? 0,
-              cost: 0,
+              cost: calculateCost(
+                model,
+                response?.usageMetadata?.promptTokenCount ?? 0,
+                response?.usageMetadata?.candidatesTokenCount ?? 0,
+              ),
             };
           },
         );

--- a/packages/instrumentation/src/instrumentations/openai.ts
+++ b/packages/instrumentation/src/instrumentations/openai.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { diag } from "@opentelemetry/api";
 import { traceLLMCall } from "../spans.js";
 import type { LLMCallOutput } from "../spans.js";
+import { calculateCost } from "../pricing.js";
 import { register } from "./registry.js";
 import type { Instrumentation } from "./types.js";
 
@@ -81,7 +82,11 @@ const openaiInstrumentation: Instrumentation = {
                 completion: response?.choices?.[0]?.message?.content ?? "",
                 inputTokens: response?.usage?.prompt_tokens ?? 0,
                 outputTokens: response?.usage?.completion_tokens ?? 0,
-                cost: 0,
+                cost: calculateCost(
+                  response?.model ?? model,
+                  response?.usage?.prompt_tokens ?? 0,
+                  response?.usage?.completion_tokens ?? 0,
+                ),
               };
             },
           );
@@ -120,7 +125,11 @@ const openaiInstrumentation: Instrumentation = {
                 completion: "[embedding]",
                 inputTokens: response?.usage?.prompt_tokens ?? 0,
                 outputTokens: 0,
-                cost: 0,
+                cost: calculateCost(
+                  response?.model ?? model,
+                  response?.usage?.prompt_tokens ?? 0,
+                  0,
+                ),
               };
             },
           );

--- a/packages/instrumentation/src/pricing.ts
+++ b/packages/instrumentation/src/pricing.ts
@@ -1,0 +1,70 @@
+/**
+ * Built-in pricing table for major LLM models.
+ * Prices in USD per 1M tokens (input / output).
+ * Updated: March 2026.
+ */
+
+export interface ModelPricing {
+  readonly inputPer1M: number;
+  readonly outputPer1M: number;
+}
+
+const BUILT_IN_PRICING: Record<string, ModelPricing> = {
+  // OpenAI
+  "gpt-4o": { inputPer1M: 2.5, outputPer1M: 10 },
+  "gpt-4o-mini": { inputPer1M: 0.15, outputPer1M: 0.6 },
+  "gpt-4-turbo": { inputPer1M: 10, outputPer1M: 30 },
+  "gpt-4.1": { inputPer1M: 2, outputPer1M: 8 },
+  "gpt-4.1-mini": { inputPer1M: 0.4, outputPer1M: 1.6 },
+  "gpt-4.1-nano": { inputPer1M: 0.1, outputPer1M: 0.4 },
+  o3: { inputPer1M: 10, outputPer1M: 40 },
+  "o3-mini": { inputPer1M: 1.1, outputPer1M: 4.4 },
+  "o4-mini": { inputPer1M: 1.1, outputPer1M: 4.4 },
+
+  // Anthropic
+  "claude-opus-4-20250514": { inputPer1M: 15, outputPer1M: 75 },
+  "claude-sonnet-4-20250514": { inputPer1M: 3, outputPer1M: 15 },
+  "claude-haiku-3-5-20241022": { inputPer1M: 0.8, outputPer1M: 4 },
+
+  // Google Gemini
+  "gemini-2.5-pro": { inputPer1M: 1.25, outputPer1M: 10 },
+  "gemini-2.5-flash": { inputPer1M: 0.15, outputPer1M: 0.6 },
+  "gemini-2.0-flash": { inputPer1M: 0.1, outputPer1M: 0.4 },
+};
+
+let customPricing: Record<string, ModelPricing> = {};
+
+/**
+ * Set custom pricing for models (overrides built-in prices).
+ * Useful for enterprise contracts or custom/fine-tuned models.
+ */
+export function setCustomPricing(pricing: Record<string, ModelPricing>) {
+  customPricing = { ...pricing };
+}
+
+/**
+ * Get pricing for a model. Custom pricing takes precedence.
+ * Returns undefined if model is not in any pricing table.
+ */
+export function getModelPricing(model: string): ModelPricing | undefined {
+  return customPricing[model] ?? BUILT_IN_PRICING[model];
+}
+
+/**
+ * Calculate cost for a given model and token counts.
+ * Returns 0 if model pricing is not found.
+ */
+export function calculateCost(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const pricing = getModelPricing(model);
+  if (!pricing) return 0;
+
+  const cost =
+    (inputTokens / 1_000_000) * pricing.inputPer1M +
+    (outputTokens / 1_000_000) * pricing.outputPer1M;
+
+  return Math.round(cost * 1_000_000) / 1_000_000;
+}


### PR DESCRIPTION
## Summary
- Built-in pricing table for major models (OpenAI, Anthropic, Gemini)
- Auto-instrumentation now calculates cost from token counts automatically
- `setCustomPricing()` for enterprise/custom models
- `calculateCost()` exported for manual use

## Test plan
- [x] Build + typecheck pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)