### PR TITLE
feat: session correlation — sessionId and sessionExtractor

### DIFF
--- a/packages/instrumentation/src/spans.ts
+++ b/packages/instrumentation/src/spans.ts
@@ -52,14 +52,21 @@ function processContent(text: string): string | undefined {
   return processed;
 }
 
+function resolveSessionId(): string | undefined {
+  const config = getConfig();
+  return config?.sessionExtractor?.() ?? config?.sessionId;
+}
+
 function setBaseAttributes(span: Span, input: LLMCallInput) {
   const prompt = processContent(input.prompt);
+  const sessionId = resolveSessionId();
   span.setAttributes({
     [GEN_AI_ATTRS.PROVIDER]: input.provider,
     [GEN_AI_ATTRS.REQUEST_MODEL]: input.model,
     [GEN_AI_ATTRS.TEMPERATURE]: input.temperature ?? 1.0,
     [GEN_AI_ATTRS.OPERATION]: "chat",
     ...(prompt !== undefined && { [GEN_AI_ATTRS.PROMPT]: prompt }),
+    ...(sessionId !== undefined && { [GEN_AI_ATTRS.SESSION_ID]: sessionId }),
   });
 }
 

--- a/packages/instrumentation/src/types.ts
+++ b/packages/instrumentation/src/types.ts
@@ -72,6 +72,7 @@ export const GEN_AI_ATTRS = {
   COST: "gen_ai.toad_eye.cost",
   STATUS: "gen_ai.toad_eye.status",
   ERROR: "error.type",
+  SESSION_ID: "session.id",
 } as const;
 
 /** @deprecated Use GEN_AI_ATTRS instead. Kept for backward compatibility. */
@@ -106,4 +107,8 @@ export interface ToadEyeConfig {
   /** Regex patterns to redact from prompt/completion text before recording. */
   readonly redactPatterns?: readonly RegExp[] | undefined;
   readonly instrument?: readonly LLMProvider[] | undefined;
+  /** Static session ID — all spans will carry this value as `session.id`. */
+  readonly sessionId?: string | undefined;
+  /** Dynamic session ID extractor — called per traceLLMCall to resolve session ID. */
+  readonly sessionExtractor?: (() => string | undefined) | undefined;
 }


### PR DESCRIPTION
## Summary
- `sessionId` config option — static session ID attached to all spans
- `sessionExtractor` config option — dynamic callback, called per `traceLLMCall`
- Recorded as `session.id` span attribute
- Extractor takes precedence over static value

## Test plan
- [x] Build + typecheck pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)