### PR TITLE
chore: expand CI with format check and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  typecheck:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,3 +18,5 @@ jobs:
       - run: npm ci
       - run: npm run build --workspace=packages/instrumentation
       - run: npx tsc --noEmit
+      - run: npm run format:check
+      - run: npm run test --workspace=packages/instrumentation


### PR DESCRIPTION
## Summary
- Add `npm run format:check` to CI
- Add `npm run test` (Vitest) to CI
- Renamed job from `typecheck` to `check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)