### PR TITLE
chore: add optional peer deps for LLM SDKs

### DIFF
--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -52,6 +52,22 @@
     "nodemailer": "^6.9.0",
     "yaml": "^2.7.0"
   },
+  "peerDependencies": {
+    "openai": ">=4.0.0",
+    "@anthropic-ai/sdk": ">=0.30.0",
+    "@google/generative-ai": ">=0.20.0"
+  },
+  "peerDependenciesMeta": {
+    "openai": {
+      "optional": true
+    },
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@google/generative-ai": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/nodemailer": "^7.0.11",
     "vitest": "^4.1.0"


### PR DESCRIPTION
## Summary
- `openai`, `@anthropic-ai/sdk`, `@google/generative-ai` as optional peer deps
- npm will hint users to install them when using `instrument` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)