### PR TITLE
chore: config validation on init

### DIFF
--- a/packages/instrumentation/src/tracer.test.ts
+++ b/packages/instrumentation/src/tracer.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock OTel SDK to avoid real initialization
+vi.mock("@opentelemetry/sdk-node", () => ({
+  NodeSDK: class {
+    start() {}
+    shutdown() {}
+  },
+}));
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn(),
+}));
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+  OTLPTraceExporter: vi.fn(),
+}));
+vi.mock("@opentelemetry/exporter-metrics-otlp-http", () => ({
+  OTLPMetricExporter: vi.fn(),
+}));
+vi.mock("@opentelemetry/sdk-metrics", () => ({
+  PeriodicExportingMetricReader: vi.fn(),
+}));
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  ATTR_SERVICE_NAME: "service.name",
+}));
+vi.mock("@opentelemetry/api", () => ({
+  metrics: { getMeter: () => ({}) },
+  diag: { warn: vi.fn(), debug: vi.fn() },
+  trace: { getTracer: () => ({}) },
+}));
+vi.mock("./metrics.js", () => ({ initMetrics: vi.fn() }));
+vi.mock("./instrumentations/registry.js", () => ({
+  enableAll: vi.fn(),
+  disableAll: vi.fn(),
+}));
+vi.mock("./instrumentations/openai.js", () => ({}));
+vi.mock("./instrumentations/anthropic.js", () => ({}));
+vi.mock("./instrumentations/gemini.js", () => ({}));
+
+const { initObservability, shutdown } = await import("./tracer.js");
+
+describe("initObservability — config validation", () => {
+  it("throws on empty serviceName", () => {
+    expect(() => initObservability({ serviceName: "" })).toThrow(
+      "serviceName is required",
+    );
+  });
+
+  it("throws on whitespace-only serviceName", () => {
+    expect(() => initObservability({ serviceName: "   " })).toThrow(
+      "serviceName is required",
+    );
+  });
+
+  it("throws on invalid endpoint", () => {
+    expect(() =>
+      initObservability({ serviceName: "test", endpoint: "not-a-url" }),
+    ).toThrow("endpoint must be a valid URL");
+  });
+
+  it("accepts valid config", async () => {
+    // Clean up any previous SDK state
+    await shutdown();
+    expect(() =>
+      initObservability({ serviceName: "test-service" }),
+    ).not.toThrow();
+    await shutdown();
+  });
+});

--- a/packages/instrumentation/src/tracer.ts
+++ b/packages/instrumentation/src/tracer.ts
@@ -22,9 +22,21 @@ export function getConfig() {
   return currentConfig;
 }
 
+function validateConfig(config: ToadEyeConfig) {
+  if (!config.serviceName?.trim()) {
+    throw new Error("toad-eye: serviceName is required and cannot be empty");
+  }
+  if (config.endpoint !== undefined && !config.endpoint.startsWith("http")) {
+    throw new Error(
+      `toad-eye: endpoint must be a valid URL, got "${config.endpoint}"`,
+    );
+  }
+}
+
 export function initObservability(config: ToadEyeConfig) {
   if (sdk) return;
 
+  validateConfig(config);
   const endpoint = config.endpoint ?? DEFAULT_ENDPOINT;
 
   const resource = resourceFromAttributes({


### PR DESCRIPTION
## Summary
- Validate `serviceName` (required, non-empty) and `endpoint` (valid URL) at init
- Fail-fast: throws immediately instead of silently misconfiguring
- 4 new tests

## Test plan
- [x] 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)