### PR TITLE
feat: agent step tracking — traceAgentStep and traceAgentQuery (#37)

### DIFF
--- a/packages/instrumentation/src/agent.test.ts
+++ b/packages/instrumentation/src/agent.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSpan = {
+  setAttribute: vi.fn(),
+  setAttributes: vi.fn(),
+  setStatus: vi.fn(),
+  end: vi.fn(),
+};
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: {
+    getTracer: () => ({
+      startSpan: (_name: string) => mockSpan,
+      startActiveSpan: (
+        _name: string,
+        fn: (span: typeof mockSpan) => unknown,
+      ) => fn(mockSpan),
+    }),
+  },
+  SpanStatusCode: { OK: 0, ERROR: 2 },
+  metrics: { getMeter: () => ({}) },
+  diag: { warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockRecordAgentSteps = vi.fn();
+const mockRecordAgentToolUsage = vi.fn();
+
+vi.mock("./metrics.js", () => ({
+  recordAgentSteps: (...args: unknown[]) => mockRecordAgentSteps(...args),
+  recordAgentToolUsage: (...args: unknown[]) =>
+    mockRecordAgentToolUsage(...args),
+}));
+
+let mockConfig: Record<string, unknown> = {};
+vi.mock("./tracer.js", () => ({
+  getConfig: () => mockConfig,
+}));
+
+const { traceAgentStep, traceAgentQuery } = await import("./agent.js");
+
+describe("traceAgentStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = {};
+  });
+
+  it("creates a span with step type and number", () => {
+    traceAgentStep({ type: "think", stepNumber: 1 });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.agent.step.type": "think",
+        "gen_ai.agent.step.number": 1,
+      }),
+    );
+    expect(mockSpan.end).toHaveBeenCalled();
+  });
+
+  it("includes toolName for act steps", () => {
+    traceAgentStep({ type: "act", stepNumber: 2, toolName: "web-search" });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.agent.tool.name": "web-search",
+      }),
+    );
+  });
+
+  it("records tool usage metric for act steps", () => {
+    traceAgentStep({ type: "act", stepNumber: 2, toolName: "web-search" });
+
+    expect(mockRecordAgentToolUsage).toHaveBeenCalledWith("web-search");
+  });
+
+  it("does not record tool usage for non-act steps", () => {
+    traceAgentStep({ type: "think", stepNumber: 1 });
+
+    expect(mockRecordAgentToolUsage).not.toHaveBeenCalled();
+  });
+
+  it("includes content when recordContent is enabled", () => {
+    traceAgentStep({ type: "think", stepNumber: 1, content: "reasoning here" });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.agent.step.content": "reasoning here",
+      }),
+    );
+  });
+
+  it("omits content when recordContent is false", () => {
+    mockConfig = { recordContent: false };
+    traceAgentStep({
+      type: "think",
+      stepNumber: 1,
+      content: "secret reasoning",
+    });
+
+    const attrs = mockSpan.setAttributes.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(attrs).not.toHaveProperty("gen_ai.agent.step.content");
+  });
+});
+
+describe("traceAgentQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = {};
+  });
+
+  it("returns the result from the callback", async () => {
+    const result = await traceAgentQuery("test query", async () => {
+      return { answer: "42" };
+    });
+
+    expect(result).toEqual({ answer: "42" });
+  });
+
+  it("passes step function to callback and counts steps", async () => {
+    await traceAgentQuery("test query", async (step) => {
+      step({ type: "think", stepNumber: 1 });
+      step({ type: "act", stepNumber: 2, toolName: "calc" });
+      step({ type: "answer", stepNumber: 3 });
+    });
+
+    expect(mockRecordAgentSteps).toHaveBeenCalledWith(3);
+  });
+
+  it("records steps even when callback throws", async () => {
+    await expect(
+      traceAgentQuery("test query", async (step) => {
+        step({ type: "think", stepNumber: 1 });
+        throw new Error("agent failed");
+      }),
+    ).rejects.toThrow("agent failed");
+
+    expect(mockRecordAgentSteps).toHaveBeenCalledWith(1);
+  });
+
+  it("sets error status on span when callback throws", async () => {
+    await expect(
+      traceAgentQuery("fail", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(mockSpan.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: "boom",
+    });
+  });
+
+  it("records query content in parent span", async () => {
+    await traceAgentQuery("What is the weather?", async () => "sunny");
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.agent.step.content",
+      "What is the weather?",
+    );
+  });
+
+  it("omits query content when recordContent is false", async () => {
+    mockConfig = { recordContent: false };
+    await traceAgentQuery("secret query", async () => "result");
+
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      "gen_ai.agent.step.content",
+      expect.anything(),
+    );
+  });
+});

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -1,0 +1,105 @@
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import type { AgentStepInput } from "./types/index.js";
+import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
+import { recordAgentSteps, recordAgentToolUsage } from "./metrics.js";
+import { getConfig } from "./tracer.js";
+
+const tracer = trace.getTracer(INSTRUMENTATION_NAME);
+
+/**
+ * Record a single agent step as a child span (ReAct pattern: think → act → observe → answer).
+ *
+ * Creates a short-lived span under the current active context. Call this inside
+ * {@link traceAgentQuery} (preferred) or any other active span (e.g. traceLLMCall).
+ *
+ * - Respects `recordContent` config — content is omitted when recording is disabled.
+ * - For `act` steps with a `toolName`, automatically increments the `agent.tool_usage` metric.
+ */
+function traceAgentStep(input: AgentStepInput) {
+  const span = tracer.startSpan(`agent.step.${input.type}`);
+
+  const config = getConfig();
+  const recordContent = config?.recordContent !== false;
+
+  span.setAttributes({
+    [GEN_AI_ATTRS.AGENT_STEP_TYPE]: input.type,
+    [GEN_AI_ATTRS.AGENT_STEP_NUMBER]: input.stepNumber,
+    ...(input.toolName !== undefined && {
+      [GEN_AI_ATTRS.AGENT_TOOL_NAME]: input.toolName,
+    }),
+    ...(recordContent &&
+      input.content !== undefined && {
+        [GEN_AI_ATTRS.AGENT_STEP_CONTENT]: input.content,
+      }),
+  });
+
+  if (input.type === "act" && input.toolName !== undefined) {
+    recordAgentToolUsage(input.toolName);
+  }
+
+  span.setStatus({ code: SpanStatusCode.OK });
+  span.end();
+}
+
+/**
+ * Wrap an entire agent query in a parent span, producing structured ReAct traces.
+ *
+ * The callback receives a `step` function to record individual steps.
+ * When the callback completes, the wrapper automatically records the
+ * `agent.steps_per_query` histogram metric with the total step count.
+ *
+ * Span hierarchy in Jaeger:
+ * ```
+ * [parent] agent.query "Is anything dangerous near Earth?"
+ *   ├── agent.step.think   "I need to check asteroids"
+ *   ├── agent.step.act     tool=near-earth-asteroids
+ *   ├── agent.step.observe "7 asteroids found"
+ *   └── agent.step.answer  "7 asteroids passing safely..."
+ * ```
+ *
+ * @example
+ * ```ts
+ * const result = await traceAgentQuery("Is anything dangerous near Earth?", async (step) => {
+ *   step({ type: "think", stepNumber: 1, content: "I need to check asteroids" });
+ *   const data = await callTool("near-earth-asteroids");
+ *   step({ type: "act", stepNumber: 2, toolName: "near-earth-asteroids" });
+ *   step({ type: "observe", stepNumber: 3, content: `${data.length} asteroids found` });
+ *   step({ type: "answer", stepNumber: 4, content: "7 asteroids passing safely..." });
+ *   return { answer: "7 asteroids passing safely..." };
+ * });
+ * ```
+ */
+export async function traceAgentQuery<T>(
+  query: string,
+  fn: (step: (input: AgentStepInput) => void) => Promise<T>,
+): Promise<T> {
+  return tracer.startActiveSpan(`agent.query`, async (span) => {
+    const config = getConfig();
+    const recordContent = config?.recordContent !== false;
+
+    if (recordContent) {
+      span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, query);
+    }
+
+    let stepCount = 0;
+
+    try {
+      const result = await fn((input) => {
+        stepCount++;
+        traceAgentStep(input);
+      });
+
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      throw error;
+    } finally {
+      recordAgentSteps(stepCount);
+      span.end();
+    }
+  });
+}
+
+export { traceAgentStep };

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -11,6 +11,7 @@ export type {
   FiredAlert,
 } from "./alerts/index.js";
 export { traceLLMCall } from "./spans.js";
+export { traceAgentStep, traceAgentQuery } from "./agent.js";
 export { calculateCost, setCustomPricing, getModelPricing } from "./pricing.js";
 export type { ModelPricing } from "./pricing.js";
 export type { LLMCallInput, LLMCallOutput } from "./spans.js";
@@ -20,6 +21,8 @@ export type {
   LLMProvider,
   SpanStatus,
   MetricName,
+  AgentStepType,
+  AgentStepInput,
 } from "./types/index.js";
 export {
   GEN_AI_METRICS,

--- a/packages/instrumentation/src/metrics.ts
+++ b/packages/instrumentation/src/metrics.ts
@@ -11,6 +11,8 @@ let requestCost: Histogram;
 let tokenUsage: Counter;
 let requestsTotal: Counter;
 let errorsTotal: Counter;
+let agentStepsPerQuery: Histogram;
+let agentToolUsage: Counter;
 
 let initialized = false;
 
@@ -39,6 +41,17 @@ export function initMetrics() {
 
   errorsTotal = meter.createCounter(GEN_AI_METRICS.ERRORS, {
     description: "Total failed GenAI requests",
+  });
+
+  agentStepsPerQuery = meter.createHistogram(
+    GEN_AI_METRICS.AGENT_STEPS_PER_QUERY,
+    {
+      description: "Number of agent steps per query",
+    },
+  );
+
+  agentToolUsage = meter.createCounter(GEN_AI_METRICS.AGENT_TOOL_USAGE, {
+    description: "Agent tool invocations by tool name",
   });
 
   initialized = true;
@@ -84,5 +97,15 @@ export function recordError(provider: string, model: string) {
   errorsTotal.add(1, {
     [GEN_AI_ATTRS.PROVIDER]: provider,
     [GEN_AI_ATTRS.REQUEST_MODEL]: model,
+  });
+}
+
+export function recordAgentSteps(stepCount: number) {
+  agentStepsPerQuery.record(stepCount);
+}
+
+export function recordAgentToolUsage(toolName: string) {
+  agentToolUsage.add(1, {
+    [GEN_AI_ATTRS.AGENT_TOOL_NAME]: toolName,
   });
 }

--- a/packages/instrumentation/src/types/attributes.ts
+++ b/packages/instrumentation/src/types/attributes.ts
@@ -17,6 +17,12 @@ export const GEN_AI_ATTRS = {
   FINISH_REASONS: "gen_ai.response.finish_reasons",
   ERROR: "error.type",
 
+  // Agent step attributes
+  AGENT_STEP_TYPE: "gen_ai.agent.step.type",
+  AGENT_STEP_NUMBER: "gen_ai.agent.step.number",
+  AGENT_TOOL_NAME: "gen_ai.agent.tool.name",
+  AGENT_STEP_CONTENT: "gen_ai.agent.step.content",
+
   // toad-eye extensions
   PROMPT: "gen_ai.toad_eye.prompt",
   COMPLETION: "gen_ai.toad_eye.completion",

--- a/packages/instrumentation/src/types/index.ts
+++ b/packages/instrumentation/src/types/index.ts
@@ -16,4 +16,9 @@ export type { ToadEyeConfig } from "./config.js";
 export { GEN_AI_ATTRS, LLM_ATTRS } from "./attributes.js";
 export { GEN_AI_METRICS, LLM_METRICS } from "./metrics.js";
 export type { MetricName } from "./metrics.js";
-export type { SpanStatus, LLMSpanAttributes } from "./spans.js";
+export type {
+  SpanStatus,
+  LLMSpanAttributes,
+  AgentStepType,
+  AgentStepInput,
+} from "./spans.js";

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -12,6 +12,9 @@ export const GEN_AI_METRICS = {
   REQUEST_COST: "gen_ai.client.request.cost",
   REQUESTS: "gen_ai.client.requests",
   ERRORS: "gen_ai.client.errors",
+  // Agent metrics
+  AGENT_STEPS_PER_QUERY: "gen_ai.agent.steps_per_query",
+  AGENT_TOOL_USAGE: "gen_ai.agent.tool_usage",
 } as const;
 
 /** @deprecated Use GEN_AI_METRICS instead. Kept for backward compatibility. */

--- a/packages/instrumentation/src/types/spans.ts
+++ b/packages/instrumentation/src/types/spans.ts
@@ -3,6 +3,17 @@ import type { LLMProvider } from "./providers.js";
 /** Span status values used in trace attributes. */
 export type SpanStatus = "success" | "error";
 
+/** ReAct agent step types: think → act → observe → answer */
+export type AgentStepType = "think" | "act" | "observe" | "answer";
+
+/** Input for traceAgentStep — describes a single agent step */
+export interface AgentStepInput {
+  readonly type: AgentStepType;
+  readonly stepNumber: number;
+  readonly content?: string | undefined;
+  readonly toolName?: string | undefined;
+}
+
 /**
  * Attributes attached to every LLM span (trace).
  * These become searchable fields in Jaeger and filterable dimensions in Grafana.


### PR DESCRIPTION
## Summary
- Add `traceAgentStep()` for recording individual ReAct agent steps (think/act/observe/answer) as child OTel spans
- Add `traceAgentQuery()` wrapper that creates a parent span for the full agent cycle and auto-records `steps_per_query` histogram
- New span attributes: `gen_ai.agent.step.type`, `gen_ai.agent.step.number`, `gen_ai.agent.tool.name`, `gen_ai.agent.step.content`
- New metrics: `gen_ai.agent.steps_per_query` (histogram), `gen_ai.agent.tool_usage` (counter per tool)
- Respects existing `recordContent` privacy config
- 12 unit tests covering both functions, privacy, error handling, and metric recording

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run agent.test.ts` — 12/12 tests pass
- [x] Manual: integrate with agentic-tool-router (NASA agent) and verify spans in Jaeger

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)