### PR TITLE
feat: shadow guardrails — recordGuardResult integration (#46)

### DIFF
--- a/packages/instrumentation/src/guard.test.ts
+++ b/packages/instrumentation/src/guard.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSpan = {
+  setAttributes: vi.fn(),
+  end: vi.fn(),
+};
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: {
+    getTracer: () => ({
+      startSpan: (_name: string) => mockSpan,
+    }),
+  },
+  metrics: { getMeter: () => ({}) },
+  diag: { warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockRecordGuardEvaluation = vi.fn();
+const mockRecordGuardWouldBlock = vi.fn();
+
+vi.mock("./metrics.js", () => ({
+  recordGuardEvaluation: (...args: unknown[]) =>
+    mockRecordGuardEvaluation(...args),
+  recordGuardWouldBlock: (...args: unknown[]) =>
+    mockRecordGuardWouldBlock(...args),
+}));
+
+const { recordGuardResult } = await import("./guard.js");
+
+describe("recordGuardResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a span with guard attributes for passing result", () => {
+    recordGuardResult({
+      mode: "shadow",
+      passed: true,
+      ruleName: "schema_check",
+    });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+      "gen_ai.toad_eye.guard.mode": "shadow",
+      "gen_ai.toad_eye.guard.passed": true,
+      "gen_ai.toad_eye.guard.rule_name": "schema_check",
+    });
+    expect(mockSpan.end).toHaveBeenCalled();
+  });
+
+  it("includes failure_reason when guard fails", () => {
+    recordGuardResult({
+      mode: "shadow",
+      passed: false,
+      ruleName: "json_format",
+      failureReason: "Invalid JSON in response",
+    });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+      "gen_ai.toad_eye.guard.mode": "shadow",
+      "gen_ai.toad_eye.guard.passed": false,
+      "gen_ai.toad_eye.guard.rule_name": "json_format",
+      "gen_ai.toad_eye.guard.failure_reason": "Invalid JSON in response",
+    });
+  });
+
+  it("omits failure_reason when guard passes", () => {
+    recordGuardResult({
+      mode: "enforce",
+      passed: true,
+      ruleName: "toxicity",
+    });
+
+    const attrs = mockSpan.setAttributes.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(attrs).not.toHaveProperty("gen_ai.toad_eye.guard.failure_reason");
+  });
+
+  it("records evaluation metric for every result", () => {
+    recordGuardResult({
+      mode: "shadow",
+      passed: true,
+      ruleName: "length_check",
+    });
+
+    expect(mockRecordGuardEvaluation).toHaveBeenCalledWith("length_check");
+  });
+
+  it("records would_block metric only when guard fails", () => {
+    recordGuardResult({
+      mode: "shadow",
+      passed: false,
+      ruleName: "pii_filter",
+      failureReason: "SSN detected",
+    });
+
+    expect(mockRecordGuardWouldBlock).toHaveBeenCalledWith("pii_filter");
+  });
+
+  it("does not record would_block when guard passes", () => {
+    recordGuardResult({
+      mode: "shadow",
+      passed: true,
+      ruleName: "pii_filter",
+    });
+
+    expect(mockRecordGuardWouldBlock).not.toHaveBeenCalled();
+  });
+
+  it("works with enforce mode", () => {
+    recordGuardResult({
+      mode: "enforce",
+      passed: false,
+      ruleName: "content_policy",
+      failureReason: "Blocked content",
+    });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.toad_eye.guard.mode": "enforce",
+      }),
+    );
+    expect(mockRecordGuardEvaluation).toHaveBeenCalledWith("content_policy");
+    expect(mockRecordGuardWouldBlock).toHaveBeenCalledWith("content_policy");
+  });
+});

--- a/packages/instrumentation/src/guard.ts
+++ b/packages/instrumentation/src/guard.ts
@@ -1,0 +1,53 @@
+/**
+ * Shadow Guardrails integration — records toad-guard validation results
+ * as span attributes and metrics without blocking LLM responses.
+ *
+ * toad-guard validates each LLM response and passes the result here.
+ * In shadow mode, validation runs but never throws — results are recorded
+ * for observability only, letting you tune guardrail thresholds on
+ * production traffic before switching to enforce mode.
+ *
+ * Usage from toad-guard:
+ * ```ts
+ * import { recordGuardResult } from "toad-eye";
+ *
+ * const result = guard.validate(response);
+ * recordGuardResult(result); // records as span attrs + metrics
+ * ```
+ */
+
+import { trace } from "@opentelemetry/api";
+import type { GuardResult } from "./types/index.js";
+import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
+import { recordGuardEvaluation, recordGuardWouldBlock } from "./metrics.js";
+
+const tracer = trace.getTracer(INSTRUMENTATION_NAME);
+
+/**
+ * Record a guard validation result as span attributes and metrics.
+ *
+ * Attaches guard attributes to a child span and increments counters.
+ * If the guard failed, also increments the `would_block` counter —
+ * useful for measuring how often shadow guardrails would have blocked.
+ */
+export function recordGuardResult(result: GuardResult) {
+  const span = tracer.startSpan(`guard.evaluate.${result.ruleName}`);
+
+  span.setAttributes({
+    [GEN_AI_ATTRS.GUARD_MODE]: result.mode,
+    [GEN_AI_ATTRS.GUARD_PASSED]: result.passed,
+    [GEN_AI_ATTRS.GUARD_RULE_NAME]: result.ruleName,
+    ...(!result.passed &&
+      result.failureReason !== undefined && {
+        [GEN_AI_ATTRS.GUARD_FAILURE_REASON]: result.failureReason,
+      }),
+  });
+
+  span.end();
+
+  recordGuardEvaluation(result.ruleName);
+
+  if (!result.passed) {
+    recordGuardWouldBlock(result.ruleName);
+  }
+}

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -12,6 +12,7 @@ export type {
 } from "./alerts/index.js";
 export { traceLLMCall } from "./spans.js";
 export { traceAgentStep, traceAgentQuery } from "./agent.js";
+export { recordGuardResult } from "./guard.js";
 export { exportTrace, fetchTrace, traceToEvalYaml } from "./export.js";
 export type { ExportTraceOptions } from "./export.js";
 export { calculateCost, setCustomPricing, getModelPricing } from "./pricing.js";
@@ -25,6 +26,8 @@ export type {
   MetricName,
   AgentStepType,
   AgentStepInput,
+  GuardMode,
+  GuardResult,
 } from "./types/index.js";
 export {
   GEN_AI_METRICS,

--- a/packages/instrumentation/src/metrics.ts
+++ b/packages/instrumentation/src/metrics.ts
@@ -13,6 +13,8 @@ let requestsTotal: Counter;
 let errorsTotal: Counter;
 let agentStepsPerQuery: Histogram;
 let agentToolUsage: Counter;
+let guardEvaluations: Counter;
+let guardWouldBlock: Counter;
 
 let initialized = false;
 
@@ -52,6 +54,14 @@ export function initMetrics() {
 
   agentToolUsage = meter.createCounter(GEN_AI_METRICS.AGENT_TOOL_USAGE, {
     description: "Agent tool invocations by tool name",
+  });
+
+  guardEvaluations = meter.createCounter(GEN_AI_METRICS.GUARD_EVALUATIONS, {
+    description: "Total guard evaluations (shadow + enforce)",
+  });
+
+  guardWouldBlock = meter.createCounter(GEN_AI_METRICS.GUARD_WOULD_BLOCK, {
+    description: "Guard evaluations that would have blocked the response",
   });
 
   initialized = true;
@@ -107,5 +117,17 @@ export function recordAgentSteps(stepCount: number) {
 export function recordAgentToolUsage(toolName: string) {
   agentToolUsage.add(1, {
     [GEN_AI_ATTRS.AGENT_TOOL_NAME]: toolName,
+  });
+}
+
+export function recordGuardEvaluation(ruleName: string) {
+  guardEvaluations.add(1, {
+    [GEN_AI_ATTRS.GUARD_RULE_NAME]: ruleName,
+  });
+}
+
+export function recordGuardWouldBlock(ruleName: string) {
+  guardWouldBlock.add(1, {
+    [GEN_AI_ATTRS.GUARD_RULE_NAME]: ruleName,
   });
 }

--- a/packages/instrumentation/src/types/attributes.ts
+++ b/packages/instrumentation/src/types/attributes.ts
@@ -23,6 +23,12 @@ export const GEN_AI_ATTRS = {
   AGENT_TOOL_NAME: "gen_ai.agent.tool.name",
   AGENT_STEP_CONTENT: "gen_ai.agent.step.content",
 
+  // Guard (shadow mode) attributes
+  GUARD_MODE: "gen_ai.toad_eye.guard.mode",
+  GUARD_PASSED: "gen_ai.toad_eye.guard.passed",
+  GUARD_FAILURE_REASON: "gen_ai.toad_eye.guard.failure_reason",
+  GUARD_RULE_NAME: "gen_ai.toad_eye.guard.rule_name",
+
   // toad-eye extensions
   PROMPT: "gen_ai.toad_eye.prompt",
   COMPLETION: "gen_ai.toad_eye.completion",

--- a/packages/instrumentation/src/types/index.ts
+++ b/packages/instrumentation/src/types/index.ts
@@ -21,4 +21,6 @@ export type {
   LLMSpanAttributes,
   AgentStepType,
   AgentStepInput,
+  GuardMode,
+  GuardResult,
 } from "./spans.js";

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -15,6 +15,9 @@ export const GEN_AI_METRICS = {
   // Agent metrics
   AGENT_STEPS_PER_QUERY: "gen_ai.agent.steps_per_query",
   AGENT_TOOL_USAGE: "gen_ai.agent.tool_usage",
+  // Guard metrics
+  GUARD_EVALUATIONS: "gen_ai.toad_eye.guard.evaluations",
+  GUARD_WOULD_BLOCK: "gen_ai.toad_eye.guard.would_block",
 } as const;
 
 /** @deprecated Use GEN_AI_METRICS instead. Kept for backward compatibility. */

--- a/packages/instrumentation/src/types/spans.ts
+++ b/packages/instrumentation/src/types/spans.ts
@@ -14,6 +14,20 @@ export interface AgentStepInput {
   readonly toolName?: string | undefined;
 }
 
+/** Guard execution mode */
+export type GuardMode = "shadow" | "enforce";
+
+/**
+ * Result of a toad-guard validation — the contract between toad-guard and toad-eye.
+ * toad-guard produces this, toad-eye consumes it via recordGuardResult().
+ */
+export interface GuardResult {
+  readonly mode: GuardMode;
+  readonly passed: boolean;
+  readonly ruleName: string;
+  readonly failureReason?: string | undefined;
+}
+
 /**
  * Attributes attached to every LLM span (trace).
  * These become searchable fields in Jaeger and filterable dimensions in Grafana.


### PR DESCRIPTION
## Summary
- Add `recordGuardResult()` — toad-guard calls this to record validation results in toad-eye
- New span attributes: `guard.mode`, `guard.passed`, `guard.rule_name`, `guard.failure_reason`
- New metrics: `guard.evaluations` (counter per rule), `guard.would_block` (counter per rule)
- Types: `GuardMode`, `GuardResult` — the contract between toad-guard and toad-eye
- toad-guard does NOT depend on toad-eye — integration is optional

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] 7 unit tests: pass/fail paths, shadow/enforce modes, metric recording, attribute correctness

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)