### PR TITLE
fix: update Grafana dashboards to GenAI semantic convention names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,9 @@ After ~15s check:
 
 - Grafana: http://localhost:3100 (admin/admin) — 5 dashboards
 - Jaeger: http://localhost:16686 — traces from `toad-eye-demo`
-- Prometheus: http://localhost:9090 — raw metrics
+- Prometheus: http://localhost:9090 — raw metrics (search `gen_ai` for autocomplete)
+
+**Important:** After any feature work that touches metrics, spans, or dashboards — always do a full stack run to catch integration bugs (stale metric names, broken queries, missing labels). Suggest this to the user proactively.
 
 ## Architecture
 

--- a/infra/toad-eye/grafana/dashboards/cost-breakdown.json
+++ b/infra/toad-eye/grafana/dashboards/cost-breakdown.json
@@ -34,7 +34,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"})",
+          "expr": "sum(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"})",
           "refId": "A"
         }
       ],
@@ -59,7 +59,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1d]))",
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1d]))",
           "refId": "A"
         }
       ],
@@ -84,7 +84,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1d])) * 86400 * 30",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1d])) * 86400 * 30",
           "refId": "A"
         }
       ],
@@ -109,8 +109,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (provider) * 60",
-          "legendFormat": "{{ provider }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_provider_name) * 60",
+          "legendFormat": "{{ gen_ai_provider_name }}",
           "refId": "A"
         }
       ],
@@ -134,8 +134,8 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1m])) by (model) * 60",
-          "legendFormat": "{{ model }}",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1m])) by (gen_ai_request_model) * 60",
+          "legendFormat": "{{ gen_ai_request_model }}",
           "refId": "A"
         }
       ],
@@ -159,7 +159,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[5m])) / sum(rate(llm_request_cost_USD_count{provider=~\"$provider\", model=~\"$model\"}[5m]))",
+          "expr": "sum(rate(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m])) / sum(rate(gen_ai_client_request_cost_USD_count{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[5m]))",
           "legendFormat": "avg cost/request",
           "refId": "A"
         }
@@ -179,7 +179,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(increase(llm_request_cost_USD_sum{provider=~\"$provider\", model=~\"$model\"}[1h]))",
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum{gen_ai_provider_name=~\"$provider\", gen_ai_request_model=~\"$model\"}[1h]))",
           "legendFormat": "hourly cost",
           "refId": "A"
         }
@@ -202,7 +202,7 @@
         "name": "provider",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total, provider)",
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },
@@ -212,7 +212,7 @@
         "name": "model",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "query": "label_values(llm_requests_total{provider=~\"$provider\"}, model)",
+        "query": "label_values(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}, gen_ai_request_model)",
         "includeAll": true,
         "allValue": ".*",
         "current": { "text": "All", "value": "$__all" },


### PR DESCRIPTION
## Summary
- Migrate all 5 Grafana dashboard templates from legacy `llm_*` metric names to `gen_ai_*` conventions
- Fix label references: `provider` → `gen_ai_provider_name`, `model` → `gen_ai_request_model`
- Fix `label_values()` queries and `legendFormat` templates
- Add stack run checklist reminder to CLAUDE.md

## Context
After the OTel GenAI semconv migration in Batch 3 (#64), dashboards were never updated, causing "no data" in Grafana while Prometheus had all the metrics.

## Test plan
- [x] `npx toad-eye down && npx toad-eye init` (re-scaffold with updated templates)
- [x] `npx toad-eye up`, run demo + load, verify Grafana dashboards show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)