### PR TITLE
feat: FinOps attribution — custom attributes + 6th dashboard (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,19 +207,43 @@ alerts:
 
 Delivery channels: Telegram, Slack webhook, generic HTTP webhook, email (SMTP).
 
+## FinOps attribution
+
+Track costs by team, user, feature, or any business dimension:
+
+```typescript
+// Global attributes — applied to all spans/metrics
+initObservability({
+  serviceName: "my-app",
+  attributes: { team: "checkout", environment: "production" },
+});
+
+// Per-request attributes — override or extend global
+await traceLLMCall(
+  {
+    provider: "openai",
+    model: "gpt-4o",
+    prompt: "Summarize order",
+    attributes: { userId: "user-123", feature: "order-summary" },
+  },
+  () => callLLM(),
+);
+```
+
 ## Grafana dashboards
 
-5 pre-built dashboards auto-provisioned on `npx toad-eye init`:
+6 pre-built dashboards auto-provisioned on `npx toad-eye init`:
 
-| Dashboard            | What it shows                                           |
-| -------------------- | ------------------------------------------------------- |
-| **Overview**         | Request rate, error rate, latency p50/p95, cost, totals |
-| **Cost Breakdown**   | Spend by provider/model, daily trend, projected monthly |
-| **Latency Analysis** | p50/p95/p99 by model, distribution histogram            |
-| **Error Drill-down** | Error rate by provider/model, error vs success          |
-| **Model Comparison** | Latency vs cost vs error rate vs throughput per model   |
+| Dashboard              | What it shows                                             |
+| ---------------------- | --------------------------------------------------------- |
+| **Overview**           | Request rate, error rate, latency p50/p95, cost, totals   |
+| **Cost Breakdown**     | Spend by provider/model, daily trend, projected monthly   |
+| **Latency Analysis**   | p50/p95/p99 by model, distribution histogram              |
+| **Error Drill-down**   | Error rate by provider/model, error vs success            |
+| **Model Comparison**   | Latency vs cost vs error rate vs throughput per model     |
+| **FinOps Attribution** | Cost by team/user/feature, projected spend, what-if table |
 
-All dashboards have `$provider` and `$model` template variables for filtering.
+All dashboards have template variables for filtering (`$provider`, `$model`, `$team`, `$feature`).
 
 ## CLI
 

--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -103,3 +103,75 @@ describe("privacy — processContent", () => {
     expect(output.completion).toBe("response");
   });
 });
+
+describe("FinOps attributes", () => {
+  beforeEach(() => {
+    mockConfig = {};
+  });
+
+  it("passes per-request attributes through to metrics", async () => {
+    const { recordRequest } = await import("../core/metrics.js");
+
+    await traceLLMCall(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "test",
+        attributes: {
+          "toad_eye.team": "checkout",
+          "toad_eye.feature": "order-summary",
+        },
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 10,
+        outputTokens: 5,
+        cost: 0.01,
+      }),
+    );
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      "openai",
+      "gpt-4o",
+      expect.objectContaining({
+        "toad_eye.team": "checkout",
+        "toad_eye.feature": "order-summary",
+      }),
+    );
+  });
+
+  it("merges global and per-request attributes (per-request wins)", async () => {
+    mockConfig = {
+      attributes: {
+        "toad_eye.team": "global-team",
+        "toad_eye.environment": "prod",
+      },
+    };
+
+    const { recordRequest } = await import("../core/metrics.js");
+
+    await traceLLMCall(
+      {
+        provider: "anthropic",
+        model: "claude-sonnet",
+        prompt: "test",
+        attributes: { "toad_eye.team": "override-team" },
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 5,
+        outputTokens: 3,
+        cost: 0.005,
+      }),
+    );
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      "anthropic",
+      "claude-sonnet",
+      expect.objectContaining({
+        "toad_eye.team": "override-team",
+        "toad_eye.environment": "prod",
+      }),
+    );
+  });
+});

--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -73,47 +73,60 @@ export function initMetrics() {
   initialized = true;
 }
 
+/** Build metric labels: provider + model + optional FinOps attributes. */
+function baseLabels(
+  provider: string,
+  model: string,
+  attrs?: Record<string, string>,
+): Record<string, string> {
+  return {
+    [GEN_AI_ATTRS.PROVIDER]: provider,
+    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
+    ...attrs,
+  };
+}
+
 export function recordRequestDuration(
   ms: number,
   provider: string,
   model: string,
+  attrs?: Record<string, string>,
 ) {
-  requestDuration.record(ms, {
-    [GEN_AI_ATTRS.PROVIDER]: provider,
-    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
-  });
+  requestDuration.record(ms, baseLabels(provider, model, attrs));
 }
 
 export function recordRequestCost(
   usd: number,
   provider: string,
   model: string,
+  attrs?: Record<string, string>,
 ) {
-  requestCost.record(usd, {
-    [GEN_AI_ATTRS.PROVIDER]: provider,
-    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
-  });
+  requestCost.record(usd, baseLabels(provider, model, attrs));
 }
 
-export function recordTokens(count: number, provider: string, model: string) {
-  tokenUsage.add(count, {
-    [GEN_AI_ATTRS.PROVIDER]: provider,
-    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
-  });
+export function recordTokens(
+  count: number,
+  provider: string,
+  model: string,
+  attrs?: Record<string, string>,
+) {
+  tokenUsage.add(count, baseLabels(provider, model, attrs));
 }
 
-export function recordRequest(provider: string, model: string) {
-  requestsTotal.add(1, {
-    [GEN_AI_ATTRS.PROVIDER]: provider,
-    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
-  });
+export function recordRequest(
+  provider: string,
+  model: string,
+  attrs?: Record<string, string>,
+) {
+  requestsTotal.add(1, baseLabels(provider, model, attrs));
 }
 
-export function recordError(provider: string, model: string) {
-  errorsTotal.add(1, {
-    [GEN_AI_ATTRS.PROVIDER]: provider,
-    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
-  });
+export function recordError(
+  provider: string,
+  model: string,
+  attrs?: Record<string, string>,
+) {
+  errorsTotal.add(1, baseLabels(provider, model, attrs));
 }
 
 export function recordAgentSteps(stepCount: number) {

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -17,6 +17,8 @@ export interface LLMCallInput {
   readonly model: string;
   readonly prompt: string;
   readonly temperature?: number | undefined;
+  /** Per-request FinOps attributes (team, userId, feature, etc). Merged with global attributes. */
+  readonly attributes?: Readonly<Record<string, string>> | undefined;
 }
 
 /** Output from the LLM call — what comes back */
@@ -57,9 +59,20 @@ function resolveSessionId(): string | undefined {
   return config?.sessionExtractor?.() ?? config?.sessionId;
 }
 
+/** Merge global config attributes with per-request attributes (per-request wins). */
+function resolveAttributes(
+  input: LLMCallInput,
+): Record<string, string> | undefined {
+  const global = getConfig()?.attributes;
+  const local = input.attributes;
+  if (!global && !local) return undefined;
+  return { ...global, ...local };
+}
+
 function setBaseAttributes(span: Span, input: LLMCallInput) {
   const prompt = processContent(input.prompt);
   const sessionId = resolveSessionId();
+  const attrs = resolveAttributes(input);
   span.setAttributes({
     [GEN_AI_ATTRS.PROVIDER]: input.provider,
     [GEN_AI_ATTRS.REQUEST_MODEL]: input.model,
@@ -67,12 +80,18 @@ function setBaseAttributes(span: Span, input: LLMCallInput) {
     [GEN_AI_ATTRS.OPERATION]: "chat",
     ...(prompt !== undefined && { [GEN_AI_ATTRS.PROMPT]: prompt }),
     ...(sessionId !== undefined && { [GEN_AI_ATTRS.SESSION_ID]: sessionId }),
+    ...attrs,
   });
 }
 
-function recordBaseMetrics(duration: number, provider: string, model: string) {
-  recordRequest(provider, model);
-  recordRequestDuration(duration, provider, model);
+function recordBaseMetrics(
+  duration: number,
+  provider: string,
+  model: string,
+  attrs?: Record<string, string>,
+) {
+  recordRequest(provider, model, attrs);
+  recordRequestDuration(duration, provider, model, attrs);
 }
 
 function setSuccessAttributes(
@@ -117,24 +136,27 @@ export async function traceLLMCall(
       try {
         const output = await fn();
         const duration = performance.now() - start;
+        const attrs = resolveAttributes(input);
 
         setSuccessAttributes(span, input, output);
-        recordBaseMetrics(duration, input.provider, input.model);
-        recordRequestCost(output.cost, input.provider, input.model);
+        recordBaseMetrics(duration, input.provider, input.model, attrs);
+        recordRequestCost(output.cost, input.provider, input.model, attrs);
         recordTokens(
           output.inputTokens + output.outputTokens,
           input.provider,
           input.model,
+          attrs,
         );
 
         return output;
       } catch (error) {
         const duration = performance.now() - start;
         const message = error instanceof Error ? error.message : String(error);
+        const attrs = resolveAttributes(input);
 
         setErrorAttributes(span, message);
-        recordBaseMetrics(duration, input.provider, input.model);
-        recordError(input.provider, input.model);
+        recordBaseMetrics(duration, input.provider, input.model, attrs);
+        recordError(input.provider, input.model, attrs);
 
         throw error;
       } finally {

--- a/packages/instrumentation/src/types/attributes.ts
+++ b/packages/instrumentation/src/types/attributes.ts
@@ -35,6 +35,12 @@ export const GEN_AI_ATTRS = {
   COST: "gen_ai.toad_eye.cost",
   STATUS: "gen_ai.toad_eye.status",
   SESSION_ID: "session.id",
+
+  // FinOps attribution
+  TEAM: "toad_eye.team",
+  USER_ID: "toad_eye.user_id",
+  FEATURE: "toad_eye.feature",
+  ENVIRONMENT: "toad_eye.environment",
 } as const;
 
 /** @deprecated Use GEN_AI_ATTRS instead. Kept for backward compatibility. */

--- a/packages/instrumentation/src/types/config.ts
+++ b/packages/instrumentation/src/types/config.ts
@@ -14,6 +14,9 @@ export interface ToadEyeConfig {
   /** Custom cloud endpoint override. Defaults to https://cloud.toad-eye.dev. */
   readonly cloudEndpoint?: string | undefined;
 
+  // FinOps attribution — global attributes applied to all spans/metrics
+  readonly attributes?: Readonly<Record<string, string>> | undefined;
+
   // Privacy
   /** Set to false to disable recording prompt/completion text in spans. */
   readonly recordContent?: boolean | undefined;

--- a/packages/instrumentation/templates/grafana/dashboards/finops-attribution.json
+++ b/packages/instrumentation/templates/grafana/dashboards/finops-attribution.json
@@ -1,0 +1,278 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Total Spend",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(gen_ai_client_request_cost_USD_sum)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Projected Monthly Spend",
+      "description": "Linear projection based on last 7 days",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(increase(gen_ai_client_request_cost_USD_sum[7d])) / 7 * 30",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Requests Today",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(increase(gen_ai_client_requests_total[24h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Avg Cost per Request",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(gen_ai_client_request_cost_USD_sum) / sum(gen_ai_client_request_cost_USD_count) or vector(0)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "decimals": 4 },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cost by Team",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (toad_eye_team) (gen_ai_client_request_cost_USD_sum{toad_eye_team=~\"$team\"})",
+          "legendFormat": "{{toad_eye_team}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value", "percent"]
+        },
+        "pieType": "donut"
+      }
+    },
+    {
+      "title": "Cost by Model (stacked by Team)",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_request_model, toad_eye_team) (gen_ai_client_request_cost_USD_sum{toad_eye_team=~\"$team\", gen_ai_request_model=~\"$model\"})",
+          "legendFormat": "{{gen_ai_request_model}} / {{toad_eye_team}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "stacking": "normal"
+      }
+    },
+    {
+      "title": "Cost by Feature / Endpoint",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sort_desc(sum by (toad_eye_feature) (gen_ai_client_request_cost_USD_sum{toad_eye_feature=~\"$feature\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "toad_eye_feature": "Feature",
+              "Value": "Cost (USD)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "Top 10 Users by Cost",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (toad_eye_user_id) (gen_ai_client_request_cost_USD_sum{toad_eye_user_id!=\"\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "toad_eye_user_id": "User ID",
+              "Value": "Cost (USD)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "Daily Cost Trend (by Team)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (toad_eye_team) (increase(gen_ai_client_request_cost_USD_sum{toad_eye_team=~\"$team\"}[1d]))",
+          "legendFormat": "{{toad_eye_team}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "What-If: Model Substitution Savings",
+      "description": "Current cost per model vs estimated cost if all traffic moved to cheapest model",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_request_model) (gen_ai_client_request_cost_USD_sum)",
+          "format": "table",
+          "instant": true,
+          "refId": "current_cost"
+        },
+        {
+          "expr": "sum by (gen_ai_request_model) (gen_ai_client_token_usage_total)",
+          "format": "table",
+          "instant": true,
+          "refId": "total_tokens"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "gen_ai_request_model": "Model",
+              "Value #current_cost": "Current Cost (USD)",
+              "Value #total_tokens": "Total Tokens"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["toad-eye", "finops", "cost"],
+  "templating": {
+    "list": [
+      {
+        "name": "team",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(gen_ai_client_request_cost_USD_sum, toad_eye_team)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "regex": ""
+      },
+      {
+        "name": "feature",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(gen_ai_client_request_cost_USD_sum, toad_eye_feature)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "regex": ""
+      },
+      {
+        "name": "model",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(gen_ai_client_request_cost_USD_sum, gen_ai_request_model)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "regex": ""
+      }
+    ]
+  },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "toad-eye / FinOps Attribution",
+  "uid": "toad-eye-finops",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
- Custom `attributes` API in `initObservability()` (global) and `traceLLMCall()` (per-request) for business-dimension cost tracking
- Attributes flow into both OTel spans AND Prometheus metric labels — queryable in PromQL
- New **FinOps Attribution** Grafana dashboard (6th) with 10 panels

## How it works
```typescript
// Global: every span/metric gets team + environment labels
initObservability({
  serviceName: 'my-app',
  attributes: { team: 'checkout', environment: 'production' },
});

// Per-request: add userId + feature, override team if needed
await traceLLMCall({
  provider: 'openai', model: 'gpt-4o', prompt: '...',
  attributes: { userId: 'user-123', feature: 'order-summary' },
}, () => callLLM());
```

## FinOps Dashboard panels
| Panel | Type |
|-------|------|
| Total Spend | stat |
| Projected Monthly Spend | stat (7d linear extrapolation) |
| Requests Today | stat |
| Avg Cost per Request | stat |
| Cost by Team | donut pie chart |
| Cost by Model (stacked by Team) | bar chart |
| Cost by Feature/Endpoint | table (sorted desc) |
| Top 10 Users by Cost | table |
| Daily Cost Trend by Team | stacked timeseries |
| What-If Model Substitution | table (cost vs tokens per model) |

Template variables: `$team`, `$feature`, `$model`

## Files changed
- `types/attributes.ts` — 4 new FinOps attribute constants
- `types/config.ts` — `attributes` option in ToadEyeConfig
- `core/spans.ts` — `attributes` in LLMCallInput, merge logic, pass to metrics
- `core/metrics.ts` — all recording functions accept optional attrs
- `templates/grafana/dashboards/finops-attribution.json` — new dashboard
- `README.md` — FinOps section + 6 dashboards table

## Test plan
- [x] 79/79 tests passing (2 new FinOps attribute tests)
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)