### PR TITLE
feat: runtime budget guards — spend limits with warn/block/downgrade (#50)

### DIFF
--- a/packages/instrumentation/src/__tests__/budget.test.ts
+++ b/packages/instrumentation/src/__tests__/budget.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { BudgetTracker } from "../budget/tracker.js";
+import { ToadBudgetExceededError } from "../budget/error.js";
+
+describe("BudgetTracker", () => {
+  describe("daily budget", () => {
+    it("allows calls within budget", () => {
+      const tracker = new BudgetTracker({ daily: 10 }, "block");
+      expect(tracker.checkBefore("openai", "gpt-4o")).toBeNull();
+    });
+
+    it("blocks when daily budget is exceeded", () => {
+      const tracker = new BudgetTracker({ daily: 1 }, "block");
+
+      // Record cost that exceeds budget
+      tracker.recordCost(1.5, "gpt-4o");
+
+      expect(() => tracker.checkBefore("openai", "gpt-4o")).toThrow(
+        ToadBudgetExceededError,
+      );
+    });
+
+    it("warns but does not block in warn mode", () => {
+      const tracker = new BudgetTracker({ daily: 1 }, "warn");
+
+      tracker.recordCost(1.5, "gpt-4o");
+
+      // Should not throw — warn mode just continues
+      expect(tracker.checkBefore("openai", "gpt-4o")).toBeNull();
+    });
+
+    it("calls downgrade callback when budget exceeded in downgrade mode", () => {
+      const downgrade = vi.fn().mockReturnValue({
+        provider: "openai",
+        model: "gpt-4o-mini",
+      });
+      const tracker = new BudgetTracker({ daily: 1 }, "downgrade", downgrade);
+
+      tracker.recordCost(1.5, "gpt-4o");
+
+      const result = tracker.checkBefore("openai", "gpt-4o");
+      expect(downgrade).toHaveBeenCalledWith({
+        provider: "openai",
+        model: "gpt-4o",
+      });
+      expect(result).toEqual({ provider: "openai", model: "gpt-4o-mini" });
+    });
+  });
+
+  describe("perModel budget", () => {
+    it("blocks specific model when its budget is exceeded", () => {
+      const tracker = new BudgetTracker({ perModel: { "gpt-4o": 5 } }, "block");
+
+      tracker.recordCost(6, "gpt-4o");
+
+      expect(() => tracker.checkBefore("openai", "gpt-4o")).toThrow(
+        ToadBudgetExceededError,
+      );
+    });
+
+    it("allows different model within its budget", () => {
+      const tracker = new BudgetTracker({ perModel: { "gpt-4o": 5 } }, "block");
+
+      tracker.recordCost(6, "gpt-4o");
+
+      // gpt-4o-mini has no limit set, should pass
+      expect(tracker.checkBefore("openai", "gpt-4o-mini")).toBeNull();
+    });
+  });
+
+  describe("perUser budget", () => {
+    it("blocks user when their budget is exceeded", () => {
+      const tracker = new BudgetTracker({ perUser: 2 }, "block");
+
+      tracker.recordCost(3, "gpt-4o", "user-123");
+
+      expect(() => tracker.checkBefore("openai", "gpt-4o", "user-123")).toThrow(
+        ToadBudgetExceededError,
+      );
+    });
+
+    it("allows different user within budget", () => {
+      const tracker = new BudgetTracker({ perUser: 2 }, "block");
+
+      tracker.recordCost(3, "gpt-4o", "user-123");
+
+      // user-456 has no spend, should pass
+      expect(tracker.checkBefore("openai", "gpt-4o", "user-456")).toBeNull();
+    });
+
+    it("ignores perUser when no userId provided", () => {
+      const tracker = new BudgetTracker({ perUser: 2 }, "block");
+
+      tracker.recordCost(3, "gpt-4o");
+
+      // No userId — perUser check skipped
+      expect(tracker.checkBefore("openai", "gpt-4o")).toBeNull();
+    });
+  });
+
+  describe("recordCost", () => {
+    it("returns null when within budget", () => {
+      const tracker = new BudgetTracker({ daily: 100 }, "warn");
+      const result = tracker.recordCost(5, "gpt-4o");
+      expect(result).toBeNull();
+    });
+
+    it("returns exceeded info when budget is crossed", () => {
+      const tracker = new BudgetTracker({ daily: 10 }, "warn");
+
+      tracker.recordCost(8, "gpt-4o");
+      const result = tracker.recordCost(5, "gpt-4o");
+
+      expect(result).toEqual({
+        budget: "daily",
+        limit: 10,
+        current: 13,
+      });
+    });
+  });
+
+  describe("getUsagePercent", () => {
+    it("returns 0 when no budget set", () => {
+      const tracker = new BudgetTracker({}, "warn");
+      expect(tracker.getUsagePercent()).toBe(0);
+    });
+
+    it("returns correct percentage", () => {
+      const tracker = new BudgetTracker({ daily: 100 }, "warn");
+      tracker.recordCost(75, "gpt-4o");
+      expect(tracker.getUsagePercent()).toBe(75);
+    });
+  });
+
+  describe("ToadBudgetExceededError", () => {
+    it("has correct message for daily budget", () => {
+      const error = new ToadBudgetExceededError({
+        budget: "daily",
+        limit: 50,
+        current: 52.3,
+      });
+      expect(error.message).toContain("daily budget exceeded");
+      expect(error.message).toContain("$50");
+      expect(error.message).toContain("$52.30");
+      expect(error.name).toBe("ToadBudgetExceededError");
+    });
+
+    it("includes model info for perModel budget", () => {
+      const error = new ToadBudgetExceededError({
+        budget: "perModel",
+        limit: 30,
+        current: 31,
+        model: "gpt-4o",
+      });
+      expect(error.message).toContain("model gpt-4o");
+      expect(error.model).toBe("gpt-4o");
+    });
+
+    it("includes userId for perUser budget", () => {
+      const error = new ToadBudgetExceededError({
+        budget: "perUser",
+        limit: 5,
+        current: 6,
+        userId: "user-123",
+      });
+      expect(error.message).toContain("user user-123");
+      expect(error.userId).toBe("user-123");
+    });
+  });
+
+  describe("state persistence", () => {
+    it("restores state from saved data", () => {
+      const tracker = new BudgetTracker({ daily: 10 }, "block");
+      const today = new Date().toISOString().slice(0, 10);
+
+      tracker.restoreState({
+        date: today,
+        totalCost: 9,
+        perUser: { "user-1": 4 },
+        perModel: { "gpt-4o": 7 },
+      });
+
+      // Should be nearly at budget
+      expect(tracker.getUsagePercent()).toBe(90);
+    });
+
+    it("ignores stale state from previous day", () => {
+      const tracker = new BudgetTracker({ daily: 10 }, "block");
+
+      tracker.restoreState({
+        date: "2020-01-01",
+        totalCost: 100,
+        perUser: {},
+        perModel: {},
+      });
+
+      // Should be fresh — stale state ignored
+      expect(tracker.getUsagePercent()).toBe(0);
+    });
+  });
+});

--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -29,12 +29,16 @@ vi.mock("../core/metrics.js", () => ({
   recordTokens: vi.fn(),
   recordRequest: vi.fn(),
   recordError: vi.fn(),
+  recordBudgetExceeded: vi.fn(),
+  recordBudgetBlocked: vi.fn(),
+  recordBudgetDowngraded: vi.fn(),
 }));
 
 // Mock tracer config
 let mockConfig: Record<string, unknown> = {};
 vi.mock("../core/tracer.js", () => ({
   getConfig: () => mockConfig,
+  getBudgetTracker: () => null,
 }));
 
 const { traceLLMCall } = await import("../core/spans.js");

--- a/packages/instrumentation/src/budget/error.ts
+++ b/packages/instrumentation/src/budget/error.ts
@@ -1,0 +1,28 @@
+import type { BudgetExceededInfo } from "./types.js";
+
+/** Thrown when onBudgetExceeded is 'block' and a budget limit is hit. */
+export class ToadBudgetExceededError extends Error {
+  readonly budget: BudgetExceededInfo["budget"];
+  readonly limit: number;
+  readonly current: number;
+  readonly model?: string | undefined;
+  readonly userId?: string | undefined;
+
+  constructor(info: BudgetExceededInfo) {
+    const target =
+      info.budget === "perModel"
+        ? ` for model ${info.model}`
+        : info.budget === "perUser"
+          ? ` for user ${info.userId}`
+          : "";
+    super(
+      `toad-eye: ${info.budget} budget exceeded${target} — limit $${info.limit}, current $${info.current.toFixed(2)}`,
+    );
+    this.name = "ToadBudgetExceededError";
+    this.budget = info.budget;
+    this.limit = info.limit;
+    this.current = info.current;
+    this.model = info.model;
+    this.userId = info.userId;
+  }
+}

--- a/packages/instrumentation/src/budget/index.ts
+++ b/packages/instrumentation/src/budget/index.ts
@@ -1,0 +1,9 @@
+export { BudgetTracker } from "./tracker.js";
+export { ToadBudgetExceededError } from "./error.js";
+export type {
+  BudgetConfig,
+  BudgetExceededMode,
+  BudgetExceededInfo,
+  BudgetState,
+  DowngradeCallback,
+} from "./types.js";

--- a/packages/instrumentation/src/budget/tracker.ts
+++ b/packages/instrumentation/src/budget/tracker.ts
@@ -1,0 +1,172 @@
+import type {
+  BudgetConfig,
+  BudgetExceededMode,
+  BudgetState,
+  BudgetExceededInfo,
+  DowngradeCallback,
+} from "./types.js";
+import { ToadBudgetExceededError } from "./error.js";
+
+function todayUTC(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export class BudgetTracker {
+  private readonly config: BudgetConfig;
+  private readonly mode: BudgetExceededMode;
+  private readonly downgrade?: DowngradeCallback | undefined;
+  private state: BudgetState;
+
+  constructor(
+    config: BudgetConfig,
+    mode: BudgetExceededMode,
+    downgrade?: DowngradeCallback,
+  ) {
+    this.config = config;
+    this.mode = mode;
+    this.downgrade = downgrade;
+    this.state = {
+      date: todayUTC(),
+      totalCost: 0,
+      perUser: new Map(),
+      perModel: new Map(),
+    };
+  }
+
+  /** Reset counters if the day has changed. */
+  private resetIfNewDay() {
+    const today = todayUTC();
+    if (this.state.date !== today) {
+      this.state = {
+        date: today,
+        totalCost: 0,
+        perUser: new Map(),
+        perModel: new Map(),
+      };
+    }
+  }
+
+  /**
+   * Check budget BEFORE making an LLM call.
+   * Returns modified provider/model if downgrade mode triggers,
+   * throws ToadBudgetExceededError if block mode triggers,
+   * returns null if no action needed.
+   */
+  checkBefore(
+    provider: string,
+    model: string,
+    userId?: string,
+  ): { provider: string; model: string } | null {
+    this.resetIfNewDay();
+
+    const exceeded = this.findExceeded(model, userId);
+    if (!exceeded) return null;
+
+    if (this.mode === "block") {
+      throw new ToadBudgetExceededError(exceeded);
+    }
+
+    if (this.mode === "downgrade" && this.downgrade) {
+      return this.downgrade({ provider, model });
+    }
+
+    // 'warn' mode — continue, warning emitted after call
+    return null;
+  }
+
+  /** Record cost AFTER a successful LLM call. Returns exceeded info if budget was just crossed. */
+  recordCost(
+    cost: number,
+    model: string,
+    userId?: string,
+  ): BudgetExceededInfo | null {
+    this.resetIfNewDay();
+
+    this.state.totalCost += cost;
+    this.state.perModel.set(
+      model,
+      (this.state.perModel.get(model) ?? 0) + cost,
+    );
+    if (userId) {
+      this.state.perUser.set(
+        userId,
+        (this.state.perUser.get(userId) ?? 0) + cost,
+      );
+    }
+
+    return this.findExceeded(model, userId);
+  }
+
+  /** Find which budget (if any) is exceeded. */
+  private findExceeded(
+    model: string,
+    userId?: string,
+  ): BudgetExceededInfo | null {
+    if (
+      this.config.daily !== undefined &&
+      this.state.totalCost >= this.config.daily
+    ) {
+      return {
+        budget: "daily",
+        limit: this.config.daily,
+        current: this.state.totalCost,
+      };
+    }
+
+    const modelLimit = this.config.perModel?.[model];
+    if (modelLimit !== undefined) {
+      const modelCost = this.state.perModel.get(model) ?? 0;
+      if (modelCost >= modelLimit) {
+        return {
+          budget: "perModel",
+          limit: modelLimit,
+          current: modelCost,
+          model,
+        };
+      }
+    }
+
+    if (this.config.perUser !== undefined && userId) {
+      const userCost = this.state.perUser.get(userId) ?? 0;
+      if (userCost >= this.config.perUser) {
+        return {
+          budget: "perUser",
+          limit: this.config.perUser,
+          current: userCost,
+          userId,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /** Get current budget usage as percentage (0-100+). */
+  getUsagePercent(): number {
+    if (this.config.daily === undefined || this.config.daily === 0) return 0;
+    this.resetIfNewDay();
+    return (this.state.totalCost / this.config.daily) * 100;
+  }
+
+  /** Get current state snapshot (for persistence or debugging). */
+  getState(): Readonly<BudgetState> {
+    this.resetIfNewDay();
+    return this.state;
+  }
+
+  /** Restore state from persistence (e.g., on startup). */
+  restoreState(saved: {
+    date: string;
+    totalCost: number;
+    perUser: Record<string, number>;
+    perModel: Record<string, number>;
+  }) {
+    if (saved.date !== todayUTC()) return; // stale state, ignore
+    this.state = {
+      date: saved.date,
+      totalCost: saved.totalCost,
+      perUser: new Map(Object.entries(saved.perUser)),
+      perModel: new Map(Object.entries(saved.perModel)),
+    };
+  }
+}

--- a/packages/instrumentation/src/budget/types.ts
+++ b/packages/instrumentation/src/budget/types.ts
@@ -1,0 +1,35 @@
+/** Budget configuration for initObservability(). */
+export interface BudgetConfig {
+  /** Max daily spend in USD for the entire application. */
+  readonly daily?: number | undefined;
+  /** Max daily spend in USD per user. Requires userId in traceLLMCall attributes. */
+  readonly perUser?: number | undefined;
+  /** Max daily spend in USD per model. */
+  readonly perModel?: Readonly<Record<string, number>> | undefined;
+}
+
+/** What happens when a budget is exceeded. */
+export type BudgetExceededMode = "warn" | "block" | "downgrade";
+
+/** Callback for 'downgrade' mode — receives original input, returns modified input. */
+export type DowngradeCallback = (original: {
+  readonly provider: string;
+  readonly model: string;
+}) => { readonly provider: string; readonly model: string };
+
+/** Internal state tracking daily spend. */
+export interface BudgetState {
+  date: string;
+  totalCost: number;
+  perUser: Map<string, number>;
+  perModel: Map<string, number>;
+}
+
+/** Info about which budget was exceeded. */
+export interface BudgetExceededInfo {
+  readonly budget: "daily" | "perUser" | "perModel";
+  readonly limit: number;
+  readonly current: number;
+  readonly model?: string | undefined;
+  readonly userId?: string | undefined;
+}

--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -16,6 +16,9 @@ let agentToolUsage: Counter;
 let guardEvaluations: Counter;
 let guardWouldBlock: Counter;
 let semanticDrift: Histogram;
+let budgetExceeded: Counter;
+let budgetBlocked: Counter;
+let budgetDowngraded: Counter;
 
 let initialized = false;
 
@@ -68,6 +71,18 @@ export function initMetrics() {
   semanticDrift = meter.createHistogram(GEN_AI_METRICS.SEMANTIC_DRIFT, {
     description:
       "Semantic drift from baseline (0 = identical, 1 = completely different)",
+  });
+
+  budgetExceeded = meter.createCounter(GEN_AI_METRICS.BUDGET_EXCEEDED, {
+    description: "Number of times a budget limit was exceeded",
+  });
+
+  budgetBlocked = meter.createCounter(GEN_AI_METRICS.BUDGET_BLOCKED, {
+    description: "Number of LLM calls blocked due to budget limits",
+  });
+
+  budgetDowngraded = meter.createCounter(GEN_AI_METRICS.BUDGET_DOWNGRADED, {
+    description: "Number of LLM calls downgraded due to budget limits",
   });
 
   initialized = true;
@@ -160,4 +175,16 @@ export function recordSemanticDrift(
     [GEN_AI_ATTRS.PROVIDER]: provider,
     [GEN_AI_ATTRS.REQUEST_MODEL]: model,
   });
+}
+
+export function recordBudgetExceeded(budgetType: string) {
+  budgetExceeded.add(1, { budget_type: budgetType });
+}
+
+export function recordBudgetBlocked(budgetType: string) {
+  budgetBlocked.add(1, { budget_type: budgetType });
+}
+
+export function recordBudgetDowngraded(budgetType: string) {
+  budgetDowngraded.add(1, { budget_type: budgetType });
 }

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -8,8 +8,12 @@ import {
   recordTokens,
   recordRequest,
   recordError,
+  recordBudgetExceeded,
+  recordBudgetBlocked,
+  recordBudgetDowngraded,
 } from "./metrics.js";
-import { getConfig } from "./tracer.js";
+import { getConfig, getBudgetTracker } from "./tracer.js";
+import { GEN_AI_ATTRS as ATTRS } from "../types/index.js";
 
 /** Input for traceLLMCall — what the user knows before calling the LLM */
 export interface LLMCallInput {
@@ -127,36 +131,93 @@ export async function traceLLMCall(
   input: LLMCallInput,
   fn: () => Promise<LLMCallOutput>,
 ): Promise<LLMCallOutput> {
+  const budget = getBudgetTracker();
+  let effectiveInput = input;
+
+  // Budget check BEFORE the LLM call
+  if (budget) {
+    const userId = input.attributes?.[ATTRS.USER_ID];
+    const override = budget.checkBefore(input.provider, input.model, userId);
+    if (override) {
+      // Downgrade mode — use modified provider/model
+      effectiveInput = {
+        ...input,
+        provider: override.provider as LLMSpanAttributes["provider"],
+        model: override.model,
+      };
+      recordBudgetDowngraded("daily");
+    }
+  }
+
   return tracer.startActiveSpan(
-    `gen_ai.${input.provider}.${input.model}`,
+    `gen_ai.${effectiveInput.provider}.${effectiveInput.model}`,
     async (span) => {
       const start = performance.now();
-      setBaseAttributes(span, input);
+      setBaseAttributes(span, effectiveInput);
 
       try {
         const output = await fn();
         const duration = performance.now() - start;
-        const attrs = resolveAttributes(input);
+        const attrs = resolveAttributes(effectiveInput);
 
-        setSuccessAttributes(span, input, output);
-        recordBaseMetrics(duration, input.provider, input.model, attrs);
-        recordRequestCost(output.cost, input.provider, input.model, attrs);
-        recordTokens(
-          output.inputTokens + output.outputTokens,
-          input.provider,
-          input.model,
+        setSuccessAttributes(span, effectiveInput, output);
+        recordBaseMetrics(
+          duration,
+          effectiveInput.provider,
+          effectiveInput.model,
           attrs,
         );
+        recordRequestCost(
+          output.cost,
+          effectiveInput.provider,
+          effectiveInput.model,
+          attrs,
+        );
+        recordTokens(
+          output.inputTokens + output.outputTokens,
+          effectiveInput.provider,
+          effectiveInput.model,
+          attrs,
+        );
+
+        // Budget recording AFTER the call
+        if (budget) {
+          const userId = effectiveInput.attributes?.[ATTRS.USER_ID];
+          const exceeded = budget.recordCost(
+            output.cost,
+            effectiveInput.model,
+            userId,
+          );
+          if (exceeded) {
+            recordBudgetExceeded(exceeded.budget);
+            console.warn(
+              `toad-eye: ${exceeded.budget} budget exceeded — limit $${exceeded.limit}, current $${exceeded.current.toFixed(2)}`,
+            );
+          }
+        }
 
         return output;
       } catch (error) {
         const duration = performance.now() - start;
         const message = error instanceof Error ? error.message : String(error);
-        const attrs = resolveAttributes(input);
+        const attrs = resolveAttributes(effectiveInput);
 
         setErrorAttributes(span, message);
-        recordBaseMetrics(duration, input.provider, input.model, attrs);
-        recordError(input.provider, input.model, attrs);
+        recordBaseMetrics(
+          duration,
+          effectiveInput.provider,
+          effectiveInput.model,
+          attrs,
+        );
+        recordError(effectiveInput.provider, effectiveInput.model, attrs);
+
+        // If this was a budget block, record the metric
+        if (
+          error instanceof Error &&
+          error.name === "ToadBudgetExceededError"
+        ) {
+          recordBudgetBlocked("daily");
+        }
 
         throw error;
       } finally {

--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -7,6 +7,7 @@ import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import type { ToadEyeConfig } from "../types/index.js";
 import { initMetrics } from "./metrics.js";
 import { enableAll, disableAll } from "../instrumentations/registry.js";
+import { BudgetTracker } from "../budget/index.js";
 
 // Side-effect imports: register provider instrumentations
 import "../instrumentations/openai.js";
@@ -18,9 +19,14 @@ const DEFAULT_CLOUD_ENDPOINT = "https://cloud.toad-eye.dev";
 
 let sdk: NodeSDK | null = null;
 let currentConfig: ToadEyeConfig | null = null;
+let budgetTracker: BudgetTracker | null = null;
 
 export function getConfig() {
   return currentConfig;
+}
+
+export function getBudgetTracker() {
+  return budgetTracker;
 }
 
 function validateConfig(config: ToadEyeConfig) {
@@ -93,6 +99,14 @@ export function initObservability(config: ToadEyeConfig) {
     );
   }
 
+  if (config.budgets) {
+    budgetTracker = new BudgetTracker(
+      config.budgets,
+      config.onBudgetExceeded ?? "warn",
+      config.downgradeCallback,
+    );
+  }
+
   if (config.instrument?.length) {
     enableAll(config.instrument);
   }
@@ -104,4 +118,5 @@ export async function shutdown() {
   await sdk.shutdown();
   sdk = null;
   currentConfig = null;
+  budgetTracker = null;
 }

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -1,4 +1,16 @@
-export { initObservability, shutdown, getConfig } from "./core/tracer.js";
+export {
+  initObservability,
+  shutdown,
+  getConfig,
+  getBudgetTracker,
+} from "./core/tracer.js";
+export { BudgetTracker, ToadBudgetExceededError } from "./budget/index.js";
+export type {
+  BudgetConfig,
+  BudgetExceededMode,
+  BudgetExceededInfo,
+  DowngradeCallback,
+} from "./budget/index.js";
 export {
   AlertManager,
   startAlertsFromFile,

--- a/packages/instrumentation/src/types/config.ts
+++ b/packages/instrumentation/src/types/config.ts
@@ -1,4 +1,9 @@
 import type { LLMProvider } from "./providers.js";
+import type {
+  BudgetConfig,
+  BudgetExceededMode,
+  DowngradeCallback,
+} from "../budget/types.js";
 
 /**
  * Configuration for initObservability().
@@ -27,6 +32,14 @@ export interface ToadEyeConfig {
 
   // Auto-instrumentation
   readonly instrument?: readonly LLMProvider[] | undefined;
+
+  // Budget guards
+  /** Budget limits — daily, per-user, per-model spend caps in USD. */
+  readonly budgets?: BudgetConfig | undefined;
+  /** What to do when budget is exceeded: 'warn' (log), 'block' (throw), 'downgrade' (callback). */
+  readonly onBudgetExceeded?: BudgetExceededMode | undefined;
+  /** Callback for 'downgrade' mode — receives original provider/model, returns replacement. */
+  readonly downgradeCallback?: DowngradeCallback | undefined;
 
   // Session tracking
   /** Static session ID — all spans will carry this value as `session.id`. */

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -20,6 +20,10 @@ export const GEN_AI_METRICS = {
   GUARD_WOULD_BLOCK: "gen_ai.toad_eye.guard.would_block",
   // Drift metrics
   SEMANTIC_DRIFT: "gen_ai.toad_eye.semantic_drift",
+  // Budget metrics
+  BUDGET_EXCEEDED: "gen_ai.toad_eye.budget.exceeded",
+  BUDGET_BLOCKED: "gen_ai.toad_eye.budget.blocked",
+  BUDGET_DOWNGRADED: "gen_ai.toad_eye.budget.downgraded",
 } as const;
 
 /** @deprecated Use GEN_AI_METRICS instead. Kept for backward compatibility. */


### PR DESCRIPTION
## Summary
- Runtime budget tracking in the SDK — daily, per-user, and per-model spend limits in USD
- Three modes: `warn` (log + continue), `block` (throw `ToadBudgetExceededError`), `downgrade` (callback to switch model)
- Pre-call check (block/downgrade before LLM call happens) + post-call recording (warn after budget crossed)
- 18 new tests covering all budget scenarios

## How it works
```typescript
// Block mode — throws ToadBudgetExceededError before LLM call
initObservability({
  serviceName: 'my-app',
  budgets: { daily: 50, perUser: 5, perModel: { 'gpt-4o': 30 } },
  onBudgetExceeded: 'block',
});

// Downgrade mode — auto-switch to cheaper model
initObservability({
  serviceName: 'my-app',
  budgets: { daily: 50 },
  onBudgetExceeded: 'downgrade',
  downgradeCallback: (original) => ({
    ...original,
    model: 'gpt-4o-mini',
  }),
});

// Warn mode — log warning, continue normally
initObservability({
  serviceName: 'my-app',
  budgets: { daily: 50 },
  onBudgetExceeded: 'warn',
});
```

## Architecture
```
traceLLMCall():
  1. BEFORE call: budget.checkBefore()
     ├── block mode + exceeded → throw ToadBudgetExceededError
     ├── downgrade mode + exceeded → call downgradeCallback, modify input
     └── warn mode or within budget → continue
  2. LLM call executes
  3. AFTER call: budget.recordCost()
     └── if exceeded → console.warn + recordBudgetExceeded metric
```

## New files
- `src/budget/types.ts` — BudgetConfig, BudgetState, BudgetExceededInfo
- `src/budget/tracker.ts` — BudgetTracker class (in-memory, daily auto-reset)
- `src/budget/error.ts` — ToadBudgetExceededError with budget/limit/current info
- `src/budget/index.ts` — module exports

## Test plan
- [x] 97/97 tests passing (18 new budget tests)
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)