### PR TITLE
feat: CI baseline provider — production metrics API (#47)

### DIFF
--- a/packages/server/src/__tests__/baselines.test.ts
+++ b/packages/server/src/__tests__/baselines.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createApp } from "../app.js";
+
+import type { ServerConfig } from "../types.js";
+
+const TEST_KEY = "toad_test_key_123";
+
+const config: ServerConfig = {
+  port: 0,
+  apiKeys: [TEST_KEY],
+  rateLimit: { windowMs: 60_000, maxRequests: 100 },
+};
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${TEST_KEY}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function makeTracePayload(
+  spans: Array<{
+    name: string;
+    startNano: string;
+    endNano: string;
+    cost?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    status?: string;
+  }>,
+) {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [
+          {
+            spans: spans.map((s, i) => ({
+              traceId: `trace-${i}`,
+              spanId: `span-${i}`,
+              name: s.name,
+              startTimeUnixNano: s.startNano,
+              endTimeUnixNano: s.endNano,
+              attributes: [
+                {
+                  key: "gen_ai.toad_eye.cost",
+                  value: { doubleValue: s.cost ?? 0.01 },
+                },
+                {
+                  key: "gen_ai.usage.input_tokens",
+                  value: { intValue: String(s.inputTokens ?? 100) },
+                },
+                {
+                  key: "gen_ai.usage.output_tokens",
+                  value: { intValue: String(s.outputTokens ?? 50) },
+                },
+                {
+                  key: "gen_ai.toad_eye.status",
+                  value: { stringValue: s.status ?? "success" },
+                },
+              ],
+            })),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("GET /api/baselines", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    const result = createApp(config);
+    app = result.app;
+  });
+
+  it("returns 400 when prompt is missing", async () => {
+    const res = await app.request("/api/baselines", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("prompt");
+  });
+
+  it("returns 400 for invalid period", async () => {
+    const res = await app.request("/api/baselines?prompt=test&period=99d", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid period");
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.request("/api/baselines?prompt=test");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty baseline when no matching spans", async () => {
+    const res = await app.request(
+      "/api/baselines?prompt=nonexistent&period=7d",
+      {
+        headers: authHeaders(),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.spanCount).toBe(0);
+    expect(body.avgLatencyMs).toBe(0);
+    expect(body.prompt).toBe("nonexistent");
+    expect(body.period).toBe("7d");
+  });
+
+  it("computes baselines from ingested spans", async () => {
+    // Ingest some trace data
+    // Spans: 100ms, 200ms, 500ms latency
+    const now = BigInt(Date.now()) * 1_000_000n;
+    const payload = makeTracePayload([
+      {
+        name: "gen_ai.openai.gpt-4o",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n), // 100ms
+        cost: 0.01,
+        inputTokens: 100,
+        outputTokens: 50,
+      },
+      {
+        name: "gen_ai.openai.gpt-4o",
+        startNano: String(now),
+        endNano: String(now + 200_000_000n), // 200ms
+        cost: 0.02,
+        inputTokens: 200,
+        outputTokens: 100,
+      },
+      {
+        name: "gen_ai.openai.gpt-4o",
+        startNano: String(now),
+        endNano: String(now + 500_000_000n), // 500ms
+        cost: 0.03,
+        inputTokens: 300,
+        outputTokens: 150,
+        status: "error",
+      },
+    ]);
+
+    await app.request("/v1/traces", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify(payload),
+    });
+
+    // Query baselines
+    const res = await app.request("/api/baselines?prompt=gpt-4o&period=7d", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.spanCount).toBe(3);
+    expect(body.avgLatencyMs).toBe(267); // (100+200+500)/3 = 266.67 → 267
+    expect(body.p95LatencyMs).toBe(500);
+    expect(body.avgCost).toBeCloseTo(0.02, 4); // (0.01+0.02+0.03)/3
+    expect(body.avgTokens).toBe(300); // (150+300+450)/3
+    expect(body.errorRate).toBeCloseTo(0.3333, 3); // 1 error / 3 spans
+  });
+
+  it("defaults to 7d period when not specified", async () => {
+    const res = await app.request("/api/baselines?prompt=test", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.period).toBe("7d");
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -9,6 +9,7 @@ import { createAuthMiddleware } from "./middleware/auth.js";
 import { createRateLimitMiddleware } from "./middleware/rate-limit.js";
 import { createIngestRoutes } from "./routes/ingest.js";
 import { createHealthRoutes } from "./routes/health.js";
+import { createBaselineRoutes } from "./routes/baselines.js";
 
 export function createApp(config: ServerConfig) {
   const app = new Hono();
@@ -19,6 +20,10 @@ export function createApp(config: ServerConfig) {
 
   // Health check — no auth required
   app.route("/", createHealthRoutes(store));
+
+  // Baselines API — auth required
+  app.use("/api/*", createAuthMiddleware(config.apiKeys));
+  app.route("/", createBaselineRoutes(store));
 
   // Ingestion routes — auth + rate limiting
   app.use(

--- a/packages/server/src/routes/baselines.ts
+++ b/packages/server/src/routes/baselines.ts
@@ -1,0 +1,126 @@
+// Baselines API — compute production baselines from ingested telemetry
+// Used by toad-ci for quality gates: if new prompt is slower/costlier than baseline → CI fails
+
+import { Hono } from "hono";
+
+import type { MemoryStore } from "../storage/memory.js";
+import type { OtlpSpan } from "../types.js";
+
+/** Baseline stats computed from span data. */
+interface BaselineResponse {
+  readonly prompt: string;
+  readonly period: string;
+  readonly spanCount: number;
+  readonly avgLatencyMs: number;
+  readonly p95LatencyMs: number;
+  readonly avgCost: number;
+  readonly avgTokens: number;
+  readonly errorRate: number;
+}
+
+const PERIOD_MAP: Record<string, number> = {
+  "1d": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "14d": 14 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+function getSpanDurationMs(span: OtlpSpan): number {
+  const start = BigInt(span.startTimeUnixNano);
+  const end = BigInt(span.endTimeUnixNano);
+  return Number((end - start) / 1_000_000n);
+}
+
+function getAttrNumber(span: OtlpSpan, key: string): number {
+  const attr = span.attributes?.find((a) => a.key === key);
+  if (!attr) return 0;
+  if (attr.value.doubleValue !== undefined) return attr.value.doubleValue;
+  if (attr.value.intValue !== undefined)
+    return parseInt(attr.value.intValue, 10);
+  return 0;
+}
+
+function getAttrString(span: OtlpSpan, key: string): string | undefined {
+  const attr = span.attributes?.find((a) => a.key === key);
+  return attr?.value.stringValue;
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)] ?? 0;
+}
+
+function computeBaseline(
+  spans: readonly OtlpSpan[],
+  prompt: string,
+  period: string,
+): BaselineResponse {
+  if (spans.length === 0) {
+    return {
+      prompt,
+      period,
+      spanCount: 0,
+      avgLatencyMs: 0,
+      p95LatencyMs: 0,
+      avgCost: 0,
+      avgTokens: 0,
+      errorRate: 0,
+    };
+  }
+
+  const latencies = spans.map(getSpanDurationMs).sort((a, b) => a - b);
+  const costs = spans.map((s) => getAttrNumber(s, "gen_ai.toad_eye.cost"));
+  const tokens = spans.map(
+    (s) =>
+      getAttrNumber(s, "gen_ai.usage.input_tokens") +
+      getAttrNumber(s, "gen_ai.usage.output_tokens"),
+  );
+  const errors = spans.filter(
+    (s) => getAttrString(s, "gen_ai.toad_eye.status") === "error",
+  ).length;
+
+  const sum = (arr: readonly number[]) => arr.reduce((a, b) => a + b, 0);
+
+  return {
+    prompt,
+    period,
+    spanCount: spans.length,
+    avgLatencyMs: Math.round(sum(latencies) / spans.length),
+    p95LatencyMs: Math.round(percentile(latencies, 95)),
+    avgCost: Number((sum(costs) / spans.length).toFixed(6)),
+    avgTokens: Math.round(sum(tokens) / spans.length),
+    errorRate: Number((errors / spans.length).toFixed(4)),
+  };
+}
+
+export function createBaselineRoutes(store: MemoryStore) {
+  const app = new Hono();
+
+  // GET /api/baselines?prompt={name}&period=7d
+  app.get("/api/baselines", (c) => {
+    const prompt = c.req.query("prompt");
+    const period = c.req.query("period") ?? "7d";
+
+    if (!prompt) {
+      return c.json({ error: "Missing required query parameter: prompt" }, 400);
+    }
+
+    const periodMs = PERIOD_MAP[period];
+    if (periodMs === undefined) {
+      return c.json(
+        {
+          error: `Invalid period: ${period}. Valid values: ${Object.keys(PERIOD_MAP).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const spans = store.querySpans(prompt, periodMs);
+    const baseline = computeBaseline(spans, prompt, period);
+
+    return c.json(baseline);
+  });
+
+  return app;
+}

--- a/packages/server/src/storage/memory.ts
+++ b/packages/server/src/storage/memory.ts
@@ -4,6 +4,7 @@
 import type {
   OtlpTracePayload,
   OtlpMetricsPayload,
+  OtlpSpan,
   StoredTrace,
   StoredMetrics,
 } from "../types.js";
@@ -64,6 +65,32 @@ export class MemoryStore {
       }
     }
     return count;
+  }
+
+  /**
+   * Query spans matching a name pattern within a time period.
+   * Used by the baselines API to compute aggregated stats.
+   */
+  querySpans(namePattern: string, periodMs: number): readonly OtlpSpan[] {
+    const cutoff = Date.now() - periodMs;
+    const result: OtlpSpan[] = [];
+
+    for (const t of this.traces) {
+      const receivedAt = new Date(t.receivedAt).getTime();
+      if (receivedAt < cutoff) continue;
+
+      for (const rs of t.payload.resourceSpans) {
+        for (const ss of rs.scopeSpans) {
+          for (const span of ss.spans) {
+            if (span.name.includes(namePattern)) {
+              result.push(span);
+            }
+          }
+        }
+      }
+    }
+
+    return result;
   }
 
   clear() {


### PR DESCRIPTION
## Summary
- New `GET /api/baselines` endpoint in `packages/server` — computes production baselines from ingested telemetry
- toad-ci can query this to get production p95 latency, avg cost, error rate — and fail CI if a new prompt regresses
- Auth required (same Bearer token as ingestion)

## How it works
```bash
# Query baselines for spans matching "gpt-4o" over last 7 days
curl -H "Authorization: Bearer toad_xxx" \
  "http://localhost:4319/api/baselines?prompt=gpt-4o&period=7d"
```

Response:
```json
{
  "prompt": "gpt-4o",
  "period": "7d",
  "spanCount": 1234,
  "avgLatencyMs": 450,
  "p95LatencyMs": 890,
  "avgCost": 0.0125,
  "avgTokens": 350,
  "errorRate": 0.02
}
```

CI quality gate example: if production p95 = 890ms but new prompt gives 2000ms → CI fails.

## Files changed
- `routes/baselines.ts` — baseline computation (avg, p95, error rate from OTLP spans)
- `storage/memory.ts` — `querySpans()` method for time-windowed span search
- `app.ts` — wire baselines route with auth
- `__tests__/baselines.test.ts` — 6 tests

## Test plan
- [x] 30/30 server tests passing (6 new)
- [x] 97/97 instrumentation tests passing
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)