### PR TITLE
feat: MCP live query APIs — errors, model comparison, metrics (#48)

### DIFF
--- a/packages/server/mcp-tools.json
+++ b/packages/server/mcp-tools.json
@@ -1,0 +1,73 @@
+{
+  "name": "toad-eye",
+  "description": "Live LLM observability queries from toad-eye server",
+  "tools": [
+    {
+      "name": "toad_query_metrics",
+      "description": "Query aggregated LLM telemetry — total spans, providers, models, cost, tokens, error rate over a time period.",
+      "endpoint": "GET /api/query",
+      "parameters": {
+        "period": {
+          "type": "string",
+          "description": "Time window: 1h, 6h, 1d, 7d, 30d",
+          "default": "7d"
+        }
+      },
+      "example": "GET /api/query?period=7d"
+    },
+    {
+      "name": "toad_recent_errors",
+      "description": "Get recent LLM errors with context — trace ID, error type, provider, model, duration.",
+      "endpoint": "GET /api/errors",
+      "parameters": {
+        "limit": {
+          "type": "number",
+          "description": "Max errors to return (1-100)",
+          "default": 10
+        },
+        "period": {
+          "type": "string",
+          "description": "Time window: 1h, 6h, 1d, 7d, 30d",
+          "default": "1d"
+        }
+      },
+      "example": "GET /api/errors?limit=5&period=1d"
+    },
+    {
+      "name": "toad_compare_models",
+      "description": "Compare LLM models side by side — latency, cost, tokens, error rate.",
+      "endpoint": "GET /api/models/compare",
+      "parameters": {
+        "models": {
+          "type": "string",
+          "description": "Comma-separated model names to compare",
+          "required": true
+        },
+        "period": {
+          "type": "string",
+          "description": "Time window: 1h, 6h, 1d, 7d, 30d",
+          "default": "7d"
+        }
+      },
+      "example": "GET /api/models/compare?models=gpt-4o,gpt-4o-mini,claude-sonnet&period=7d"
+    },
+    {
+      "name": "toad_baselines",
+      "description": "Get production baselines for a prompt/span — avg/p95 latency, cost, tokens, error rate. Used for CI quality gates.",
+      "endpoint": "GET /api/baselines",
+      "parameters": {
+        "prompt": {
+          "type": "string",
+          "description": "Span name pattern to match",
+          "required": true
+        },
+        "period": {
+          "type": "string",
+          "description": "Baseline period: 1d, 7d, 14d, 30d",
+          "default": "7d"
+        }
+      },
+      "example": "GET /api/baselines?prompt=gpt-4o&period=7d"
+    }
+  ]
+}

--- a/packages/server/src/__tests__/query.test.ts
+++ b/packages/server/src/__tests__/query.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createApp } from "../app.js";
+
+import type { ServerConfig } from "../types.js";
+
+const TEST_KEY = "toad_test_key_123";
+
+const config: ServerConfig = {
+  port: 0,
+  apiKeys: [TEST_KEY],
+  rateLimit: { windowMs: 60_000, maxRequests: 100 },
+};
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${TEST_KEY}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function makeTracePayload(
+  spans: Array<{
+    name: string;
+    startNano: string;
+    endNano: string;
+    provider?: string;
+    model?: string;
+    cost?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    status?: string;
+    error?: string;
+  }>,
+) {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [
+          {
+            spans: spans.map((s, i) => ({
+              traceId: `trace-${i}`,
+              spanId: `span-${i}`,
+              name: s.name,
+              startTimeUnixNano: s.startNano,
+              endTimeUnixNano: s.endNano,
+              attributes: [
+                {
+                  key: "gen_ai.provider.name",
+                  value: { stringValue: s.provider ?? "openai" },
+                },
+                {
+                  key: "gen_ai.request.model",
+                  value: { stringValue: s.model ?? "gpt-4o" },
+                },
+                {
+                  key: "gen_ai.toad_eye.cost",
+                  value: { doubleValue: s.cost ?? 0.01 },
+                },
+                {
+                  key: "gen_ai.usage.input_tokens",
+                  value: { intValue: String(s.inputTokens ?? 100) },
+                },
+                {
+                  key: "gen_ai.usage.output_tokens",
+                  value: { intValue: String(s.outputTokens ?? 50) },
+                },
+                {
+                  key: "gen_ai.toad_eye.status",
+                  value: { stringValue: s.status ?? "success" },
+                },
+                ...(s.error
+                  ? [{ key: "error.type", value: { stringValue: s.error } }]
+                  : []),
+              ],
+            })),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function ingestSpans(
+  app: ReturnType<typeof createApp>["app"],
+  spans: Parameters<typeof makeTracePayload>[0],
+) {
+  await app.request("/v1/traces", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(makeTracePayload(spans)),
+  });
+}
+
+const now = BigInt(Date.now()) * 1_000_000n;
+
+describe("GET /api/errors", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    app = createApp(config).app;
+  });
+
+  it("returns empty list when no errors", async () => {
+    const res = await app.request("/api/errors?period=1d", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(0);
+    expect(body.errors).toEqual([]);
+  });
+
+  it("returns recent errors with context", async () => {
+    await ingestSpans(app, [
+      {
+        name: "gen_ai.openai.gpt-4o",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n),
+        status: "success",
+      },
+      {
+        name: "gen_ai.openai.gpt-4o",
+        startNano: String(now),
+        endNano: String(now + 200_000_000n),
+        status: "error",
+        error: "rate_limit_exceeded",
+      },
+    ]);
+
+    const res = await app.request("/api/errors?period=1d", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.count).toBe(1);
+    expect(body.errors[0].error).toBe("rate_limit_exceeded");
+    expect(body.errors[0].model).toBe("gpt-4o");
+  });
+
+  it("respects limit parameter", async () => {
+    await ingestSpans(app, [
+      {
+        name: "s1",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n),
+        status: "error",
+        error: "e1",
+      },
+      {
+        name: "s2",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n),
+        status: "error",
+        error: "e2",
+      },
+      {
+        name: "s3",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n),
+        status: "error",
+        error: "e3",
+      },
+    ]);
+
+    const res = await app.request("/api/errors?period=1d&limit=2", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.count).toBe(2);
+  });
+});
+
+describe("GET /api/models/compare", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    app = createApp(config).app;
+  });
+
+  it("returns 400 without models param", async () => {
+    const res = await app.request("/api/models/compare?period=7d", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("compares models side by side", async () => {
+    await ingestSpans(app, [
+      {
+        name: "llm",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n),
+        model: "gpt-4o",
+        cost: 0.05,
+      },
+      {
+        name: "llm",
+        startNano: String(now),
+        endNano: String(now + 50_000_000n),
+        model: "gpt-4o-mini",
+        cost: 0.005,
+      },
+    ]);
+
+    const res = await app.request(
+      "/api/models/compare?models=gpt-4o,gpt-4o-mini&period=7d",
+      { headers: authHeaders() },
+    );
+    const body = await res.json();
+    expect(body.models).toHaveLength(2);
+
+    const gpt4o = body.models.find(
+      (m: { model: string }) => m.model === "gpt-4o",
+    );
+    const mini = body.models.find(
+      (m: { model: string }) => m.model === "gpt-4o-mini",
+    );
+    expect(gpt4o.spanCount).toBe(1);
+    expect(mini.spanCount).toBe(1);
+    expect(gpt4o.avgCost).toBeGreaterThan(mini.avgCost);
+  });
+
+  it("returns zero stats for unknown model", async () => {
+    const res = await app.request(
+      "/api/models/compare?models=nonexistent&period=7d",
+      { headers: authHeaders() },
+    );
+    const body = await res.json();
+    expect(body.models[0].spanCount).toBe(0);
+  });
+});
+
+describe("GET /api/query", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    app = createApp(config).app;
+  });
+
+  it("returns summary of all telemetry", async () => {
+    await ingestSpans(app, [
+      {
+        name: "llm",
+        startNano: String(now),
+        endNano: String(now + 100_000_000n),
+        provider: "openai",
+        model: "gpt-4o",
+        cost: 0.05,
+      },
+      {
+        name: "llm",
+        startNano: String(now),
+        endNano: String(now + 50_000_000n),
+        provider: "anthropic",
+        model: "claude-sonnet",
+        cost: 0.01,
+      },
+    ]);
+
+    const res = await app.request("/api/query?period=7d", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.spanCount).toBe(2);
+    expect(body.providers).toContain("openai");
+    expect(body.providers).toContain("anthropic");
+    expect(body.models).toContain("gpt-4o");
+    expect(body.totalCost).toBeCloseTo(0.06, 2);
+  });
+
+  it("returns empty when no data", async () => {
+    const res = await app.request("/api/query?period=7d", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.spanCount).toBe(0);
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -10,6 +10,7 @@ import { createRateLimitMiddleware } from "./middleware/rate-limit.js";
 import { createIngestRoutes } from "./routes/ingest.js";
 import { createHealthRoutes } from "./routes/health.js";
 import { createBaselineRoutes } from "./routes/baselines.js";
+import { createQueryRoutes } from "./routes/query.js";
 
 export function createApp(config: ServerConfig) {
   const app = new Hono();
@@ -21,9 +22,10 @@ export function createApp(config: ServerConfig) {
   // Health check — no auth required
   app.route("/", createHealthRoutes(store));
 
-  // Baselines API — auth required
+  // Query APIs — auth required
   app.use("/api/*", createAuthMiddleware(config.apiKeys));
   app.route("/", createBaselineRoutes(store));
+  app.route("/", createQueryRoutes(store));
 
   // Ingestion routes — auth + rate limiting
   app.use(

--- a/packages/server/src/routes/query.ts
+++ b/packages/server/src/routes/query.ts
@@ -1,0 +1,203 @@
+// Query API — live telemetry queries for MCP tools and dashboards
+// Provides: recent errors, model comparison, arbitrary metric queries
+
+import { Hono } from "hono";
+
+import type { MemoryStore } from "../storage/memory.js";
+import type { OtlpSpan } from "../types.js";
+
+const PERIOD_MAP: Record<string, number> = {
+  "1h": 60 * 60 * 1000,
+  "6h": 6 * 60 * 60 * 1000,
+  "1d": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+function getAttrString(span: OtlpSpan, key: string): string | undefined {
+  const attr = span.attributes?.find((a) => a.key === key);
+  return attr?.value.stringValue;
+}
+
+function getAttrNumber(span: OtlpSpan, key: string): number {
+  const attr = span.attributes?.find((a) => a.key === key);
+  if (!attr) return 0;
+  if (attr.value.doubleValue !== undefined) return attr.value.doubleValue;
+  if (attr.value.intValue !== undefined)
+    return parseInt(attr.value.intValue, 10);
+  return 0;
+}
+
+function getSpanDurationMs(span: OtlpSpan): number {
+  const start = BigInt(span.startTimeUnixNano);
+  const end = BigInt(span.endTimeUnixNano);
+  return Number((end - start) / 1_000_000n);
+}
+
+function parsePeriod(period: string): number | undefined {
+  return PERIOD_MAP[period];
+}
+
+export function createQueryRoutes(store: MemoryStore) {
+  const app = new Hono();
+
+  // GET /api/errors?limit=10&period=1d — recent errors with context
+  app.get("/api/errors", (c) => {
+    const limit = Math.min(parseInt(c.req.query("limit") ?? "10", 10), 100);
+    const period = c.req.query("period") ?? "1d";
+    const periodMs = parsePeriod(period);
+
+    if (periodMs === undefined) {
+      return c.json(
+        {
+          error: `Invalid period. Valid: ${Object.keys(PERIOD_MAP).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const allSpans = store.querySpans("", periodMs);
+    const errorSpans = allSpans
+      .filter((s) => getAttrString(s, "gen_ai.toad_eye.status") === "error")
+      .slice(-limit)
+      .reverse();
+
+    const errors = errorSpans.map((s) => ({
+      traceId: s.traceId,
+      spanId: s.spanId,
+      name: s.name,
+      durationMs: getSpanDurationMs(s),
+      error: getAttrString(s, "error.type") ?? "unknown",
+      provider: getAttrString(s, "gen_ai.provider.name"),
+      model: getAttrString(s, "gen_ai.request.model"),
+    }));
+
+    return c.json({ period, count: errors.length, errors });
+  });
+
+  // GET /api/models/compare?models=gpt-4o,claude-sonnet&period=7d
+  app.get("/api/models/compare", (c) => {
+    const modelsParam = c.req.query("models");
+    const period = c.req.query("period") ?? "7d";
+    const periodMs = parsePeriod(period);
+
+    if (!modelsParam) {
+      return c.json(
+        { error: "Missing required parameter: models (comma-separated)" },
+        400,
+      );
+    }
+
+    if (periodMs === undefined) {
+      return c.json(
+        {
+          error: `Invalid period. Valid: ${Object.keys(PERIOD_MAP).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const modelNames = modelsParam.split(",").map((m) => m.trim());
+    const allSpans = store.querySpans("", periodMs);
+
+    const comparison = modelNames.map((model) => {
+      const spans = allSpans.filter(
+        (s) => getAttrString(s, "gen_ai.request.model") === model,
+      );
+
+      if (spans.length === 0) {
+        return {
+          model,
+          spanCount: 0,
+          avgLatencyMs: 0,
+          avgCost: 0,
+          avgTokens: 0,
+          errorRate: 0,
+        };
+      }
+
+      const latencies = spans.map(getSpanDurationMs);
+      const costs = spans.map((s) => getAttrNumber(s, "gen_ai.toad_eye.cost"));
+      const tokens = spans.map(
+        (s) =>
+          getAttrNumber(s, "gen_ai.usage.input_tokens") +
+          getAttrNumber(s, "gen_ai.usage.output_tokens"),
+      );
+      const errors = spans.filter(
+        (s) => getAttrString(s, "gen_ai.toad_eye.status") === "error",
+      ).length;
+
+      const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
+
+      return {
+        model,
+        spanCount: spans.length,
+        avgLatencyMs: Math.round(sum(latencies) / spans.length),
+        avgCost: Number((sum(costs) / spans.length).toFixed(6)),
+        avgTokens: Math.round(sum(tokens) / spans.length),
+        errorRate: Number((errors / spans.length).toFixed(4)),
+      };
+    });
+
+    return c.json({ period, models: comparison });
+  });
+
+  // GET /api/query?period=7d — summary of all ingested telemetry
+  app.get("/api/query", (c) => {
+    const period = c.req.query("period") ?? "7d";
+    const periodMs = parsePeriod(period);
+
+    if (periodMs === undefined) {
+      return c.json(
+        {
+          error: `Invalid period. Valid: ${Object.keys(PERIOD_MAP).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const allSpans = store.querySpans("", periodMs);
+
+    if (allSpans.length === 0) {
+      return c.json({
+        period,
+        spanCount: 0,
+        providers: [],
+        models: [],
+        totalCost: 0,
+        totalTokens: 0,
+        errorRate: 0,
+      });
+    }
+
+    const providers = new Set<string>();
+    const models = new Set<string>();
+    let totalCost = 0;
+    let totalTokens = 0;
+    let errorCount = 0;
+
+    for (const s of allSpans) {
+      const provider = getAttrString(s, "gen_ai.provider.name");
+      const model = getAttrString(s, "gen_ai.request.model");
+      if (provider) providers.add(provider);
+      if (model) models.add(model);
+      totalCost += getAttrNumber(s, "gen_ai.toad_eye.cost");
+      totalTokens +=
+        getAttrNumber(s, "gen_ai.usage.input_tokens") +
+        getAttrNumber(s, "gen_ai.usage.output_tokens");
+      if (getAttrString(s, "gen_ai.toad_eye.status") === "error") errorCount++;
+    }
+
+    return c.json({
+      period,
+      spanCount: allSpans.length,
+      providers: [...providers],
+      models: [...models],
+      totalCost: Number(totalCost.toFixed(4)),
+      totalTokens,
+      errorRate: Number((errorCount / allSpans.length).toFixed(4)),
+    });
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary
- Three new query API endpoints for live telemetry — designed for MCP tool integration
- `GET /api/query` — aggregated summary (spans, providers, cost, error rate)
- `GET /api/errors` — recent errors with trace context (traceId, error type, model)
- `GET /api/models/compare` — side-by-side model comparison (latency, cost, tokens, errors)
- `mcp-tools.json` — MCP tool definitions for all 4 query endpoints

## MCP Tools
| Tool | What it does |
|------|-------------|
| `toad_query_metrics` | "How's my LLM usage?" — summary of all telemetry |
| `toad_recent_errors` | "What errors happened?" — last N errors with context |
| `toad_compare_models` | "Which model is better?" — side-by-side stats |
| `toad_baselines` | "What's normal?" — production baselines for CI gates |

## Example
```bash
curl -H "Authorization: Bearer toad_xxx" \
  "http://localhost:4319/api/models/compare?models=gpt-4o,gpt-4o-mini&period=7d"
```

## Test plan
- [x] 38/38 server tests passing (8 new)
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)