### PR TITLE
perf: non-blocking drift check — checkInBackground() (#94)

### DIFF
--- a/packages/instrumentation/src/__tests__/monitor.test.ts
+++ b/packages/instrumentation/src/__tests__/monitor.test.ts
@@ -94,3 +94,48 @@ describe("createDriftMonitor", () => {
     expect(drift).toBeCloseTo(1);
   });
 });
+
+describe("checkInBackground", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    baselineExists = true;
+    mockEmbed.mockResolvedValue([1, 0, 0]);
+  });
+
+  it("does not block the caller", () => {
+    const monitor = makeMonitor();
+    // checkInBackground returns void, not a Promise
+    const result = monitor.checkInBackground("response", "openai", "gpt-4o");
+    expect(result).toBeUndefined();
+  });
+
+  it("records drift metric in background", async () => {
+    const monitor = makeMonitor();
+    monitor.checkInBackground("response", "openai", "gpt-4o");
+
+    // Wait for the background promise to settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(recordSemanticDrift).toHaveBeenCalledWith(
+      expect.closeTo(0),
+      "openai",
+      "gpt-4o",
+    );
+  });
+
+  it("swallows errors silently", async () => {
+    mockEmbed.mockRejectedValue(new Error("API key invalid"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const monitor = makeMonitor();
+    // Should not throw
+    monitor.checkInBackground("response", "openai", "gpt-4o");
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Drift check failed"),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/instrumentation/src/drift/monitor.ts
+++ b/packages/instrumentation/src/drift/monitor.ts
@@ -32,6 +32,14 @@ export interface DriftMonitor {
     provider: string,
     model: string,
   ): Promise<number | undefined>;
+
+  /**
+   * Fire-and-forget drift check — does NOT block the caller.
+   * Errors are logged to console.warn, never thrown.
+   * Use this in hot paths (e.g. inside traceLLMCall) to avoid
+   * blocking the LLM response delivery.
+   */
+  checkInBackground(response: string, provider: string, model: string): void;
 }
 
 function createProvider(config: EmbeddingConfig): EmbeddingProvider {
@@ -55,19 +63,33 @@ export function createDriftMonitor(config: DriftMonitorConfig): DriftMonitor {
     );
   }
 
+  async function performCheck(
+    response: string,
+    providerName: string,
+    model: string,
+  ): Promise<number | undefined> {
+    if (baseline === undefined) return undefined;
+
+    counter++;
+    if (counter % sampleRate !== 0) return undefined;
+
+    const embedding = await provider.embed(response);
+    const drift = cosineDrift(embedding, baseline.embeddings);
+
+    recordSemanticDrift(drift, providerName, model);
+
+    return drift;
+  }
+
   return {
-    async check(response, providerName, model) {
-      if (baseline === undefined) return undefined;
+    check: performCheck,
 
-      counter++;
-      if (counter % sampleRate !== 0) return undefined;
-
-      const embedding = await provider.embed(response);
-      const drift = cosineDrift(embedding, baseline.embeddings);
-
-      recordSemanticDrift(drift, providerName, model);
-
-      return drift;
+    checkInBackground(response, providerName, model) {
+      void performCheck(response, providerName, model).catch((err) => {
+        console.warn(
+          `[toad-eye] Drift check failed (non-blocking): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
Drift monitoring runs cosine similarity O(N*D) on the main thread — blocks event loop for large baselines. New `checkInBackground()` method: fire-and-forget, errors swallowed, metrics still recorded.

## Usage
```typescript
// Before (blocking — awaits embedding + cosine):
const drift = await monitor.check(response, provider, model);

// After (non-blocking — returns immediately):
monitor.checkInBackground(response, provider, model);
```

## What changed
- `DriftMonitor` interface: new `checkInBackground()` method
- Internal: extracted shared `performCheck()`, background version wraps in `void promise.catch()`
- Errors logged to `console.warn`, never thrown
- `check()` unchanged for backward compatibility

## Test plan
- [x] 110/110 tests passing (3 new)
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)