### PR TITLE
chore: bump version to 2.1.0 for npm publish

### DIFF
--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toad-eye",
-  "version": "2.0.0",
-  "description": "Auto-instrumentation, cost tracking, and observability for LLM services",
+  "version": "2.1.0",
+  "description": "Auto-instrumentation, cost tracking, budget guards, and observability for LLM services",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,7 +38,10 @@
     "gemini",
     "cost-tracking",
     "auto-instrumentation",
-    "gen-ai"
+    "gen-ai",
+    "budget-guards",
+    "finops",
+    "streaming"
   ],
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
New in 2.1.0:
- Cloud mode (apiKey → auto HTTPS transport)
- Budget guards (daily/perUser/perModel, warn/block/downgrade)
- FinOps attribution (custom attributes on spans + metrics)
- Streaming support (OpenAI + Anthropic auto-instrumentation)
- PII protection in error messages
- Salted hashing for hashContent
- Multi-modal message extraction (images, audio)
- Non-blocking drift monitoring (checkInBackground)
- 6th Grafana dashboard (FinOps Attribution)