### PR TITLE
feat: provider health monitoring — auto-detect degraded/down (#34)

### DIFF
--- a/packages/instrumentation/templates/grafana/dashboards/provider-health.json
+++ b/packages/instrumentation/templates/grafana/dashboards/provider-health.json
@@ -1,0 +1,191 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Provider Status",
+      "description": "healthy (< 10% errors) / degraded (10-50%) / down (> 50%)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_provider_name) (rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\"}[5m])) / sum by (gen_ai_provider_name) (rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}[5m]))",
+          "legendFormat": "{{gen_ai_provider_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "range",
+              "options": {
+                "from": 0,
+                "to": 0.1,
+                "result": { "text": "HEALTHY", "color": "green" }
+              }
+            },
+            {
+              "type": "range",
+              "options": {
+                "from": 0.1,
+                "to": 0.5,
+                "result": { "text": "DEGRADED", "color": "yellow" }
+              }
+            },
+            {
+              "type": "range",
+              "options": {
+                "from": 0.5,
+                "to": 1,
+                "result": { "text": "DOWN", "color": "red" }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Request Volume by Provider",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_provider_name) (rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}[5m]))",
+          "legendFormat": "{{gen_ai_provider_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 15 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Error Rate by Provider (5m window)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_provider_name) (rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\"}[5m])) / sum by (gen_ai_provider_name) (rate(gen_ai_client_requests_total{gen_ai_provider_name=~\"$provider\"}[5m]))",
+          "legendFormat": "{{gen_ai_provider_name}} error rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Error Breakdown by Type",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_provider_name, error_type) (rate(gen_ai_client_errors_total{gen_ai_provider_name=~\"$provider\"}[5m]))",
+          "legendFormat": "{{gen_ai_provider_name}} — {{error_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Provider Availability (24h / 7d / 30d)",
+      "description": "Percentage of time with error rate below 10%",
+      "type": "table",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "1 - (sum by (gen_ai_provider_name) (rate(gen_ai_client_errors_total[24h])) / sum by (gen_ai_provider_name) (rate(gen_ai_client_requests_total[24h])))",
+          "format": "table",
+          "instant": true,
+          "refId": "uptime_24h"
+        },
+        {
+          "expr": "1 - (sum by (gen_ai_provider_name) (rate(gen_ai_client_errors_total[7d])) / sum by (gen_ai_provider_name) (rate(gen_ai_client_requests_total[7d])))",
+          "format": "table",
+          "instant": true,
+          "refId": "uptime_7d"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "gen_ai_provider_name": "Provider",
+              "Value #uptime_24h": "Uptime 24h",
+              "Value #uptime_7d": "Uptime 7d"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "decimals": 2 },
+        "overrides": []
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["toad-eye", "provider-health"],
+  "templating": {
+    "list": [
+      {
+        "name": "provider",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "regex": ""
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "toad-eye / Provider Health",
+  "uid": "toad-eye-provider-health",
+  "version": 1
+}

--- a/packages/server/src/__tests__/providers.test.ts
+++ b/packages/server/src/__tests__/providers.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createApp } from "../app.js";
+
+import type { ServerConfig } from "../types.js";
+
+const TEST_KEY = "toad_test_key_123";
+
+const config: ServerConfig = {
+  port: 0,
+  apiKeys: [TEST_KEY],
+  rateLimit: { windowMs: 60_000, maxRequests: 100 },
+};
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${TEST_KEY}`,
+    "Content-Type": "application/json",
+  };
+}
+
+const now = BigInt(Date.now()) * 1_000_000n;
+
+function makeSpan(opts: { provider: string; status?: string; error?: string }) {
+  return {
+    traceId: `t-${Math.random()}`,
+    spanId: `s-${Math.random()}`,
+    name: "llm.call",
+    startTimeUnixNano: String(now),
+    endTimeUnixNano: String(now + 100_000_000n),
+    attributes: [
+      { key: "gen_ai.provider.name", value: { stringValue: opts.provider } },
+      {
+        key: "gen_ai.toad_eye.status",
+        value: { stringValue: opts.status ?? "success" },
+      },
+      ...(opts.error
+        ? [{ key: "error.type", value: { stringValue: opts.error } }]
+        : []),
+    ],
+  };
+}
+
+async function ingestSpans(
+  app: ReturnType<typeof createApp>["app"],
+  spans: ReturnType<typeof makeSpan>[],
+) {
+  await app.request("/v1/traces", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({
+      resourceSpans: [{ scopeSpans: [{ spans }] }],
+    }),
+  });
+}
+
+describe("GET /api/providers/health", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    app = createApp(config).app;
+  });
+
+  it("returns empty when no data", async () => {
+    const res = await app.request("/api/providers/health?period=5m", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.providers).toEqual([]);
+  });
+
+  it("shows healthy provider with no errors", async () => {
+    await ingestSpans(app, [
+      makeSpan({ provider: "openai" }),
+      makeSpan({ provider: "openai" }),
+      makeSpan({ provider: "openai" }),
+    ]);
+
+    const res = await app.request("/api/providers/health?period=5m", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0].provider).toBe("openai");
+    expect(body.providers[0].status).toBe("healthy");
+    expect(body.providers[0].errorRate).toBe(0);
+  });
+
+  it("detects degraded provider (> 10% errors)", async () => {
+    // 8 success + 2 errors = 20% error rate → degraded
+    const spans = [
+      ...Array.from({ length: 8 }, () => makeSpan({ provider: "anthropic" })),
+      makeSpan({
+        provider: "anthropic",
+        status: "error",
+        error: "rate_limit_exceeded",
+      }),
+      makeSpan({
+        provider: "anthropic",
+        status: "error",
+        error: "rate_limit_exceeded",
+      }),
+    ];
+    await ingestSpans(app, spans);
+
+    const res = await app.request("/api/providers/health?period=5m", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.providers[0].status).toBe("degraded");
+    expect(body.providers[0].rateLimitErrors).toBe(2);
+  });
+
+  it("detects down provider (> 50% errors)", async () => {
+    // 2 success + 8 errors = 80% error rate → down
+    const spans = [
+      makeSpan({ provider: "gemini" }),
+      makeSpan({ provider: "gemini" }),
+      ...Array.from({ length: 8 }, () =>
+        makeSpan({ provider: "gemini", status: "error", error: "timeout" }),
+      ),
+    ];
+    await ingestSpans(app, spans);
+
+    const res = await app.request("/api/providers/health?period=5m", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    expect(body.providers[0].status).toBe("down");
+    expect(body.providers[0].timeoutErrors).toBe(8);
+  });
+
+  it("tracks multiple providers independently", async () => {
+    await ingestSpans(app, [
+      makeSpan({ provider: "openai" }),
+      makeSpan({ provider: "openai" }),
+      makeSpan({ provider: "anthropic", status: "error", error: "500" }),
+      makeSpan({ provider: "anthropic", status: "error", error: "500" }),
+    ]);
+
+    const res = await app.request("/api/providers/health?period=5m", {
+      headers: authHeaders(),
+    });
+    const body = await res.json();
+    const openai = body.providers.find(
+      (p: { provider: string }) => p.provider === "openai",
+    );
+    const anthropic = body.providers.find(
+      (p: { provider: string }) => p.provider === "anthropic",
+    );
+
+    expect(openai.status).toBe("healthy");
+    expect(anthropic.status).toBe("down"); // 100% errors
+  });
+
+  it("requires auth", async () => {
+    const res = await app.request("/api/providers/health");
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -11,6 +11,7 @@ import { createIngestRoutes } from "./routes/ingest.js";
 import { createHealthRoutes } from "./routes/health.js";
 import { createBaselineRoutes } from "./routes/baselines.js";
 import { createQueryRoutes } from "./routes/query.js";
+import { createProviderRoutes } from "./routes/providers.js";
 
 export function createApp(config: ServerConfig) {
   const app = new Hono();
@@ -26,6 +27,7 @@ export function createApp(config: ServerConfig) {
   app.use("/api/*", createAuthMiddleware(config.apiKeys));
   app.route("/", createBaselineRoutes(store));
   app.route("/", createQueryRoutes(store));
+  app.route("/", createProviderRoutes(store));
 
   // Ingestion routes — auth + rate limiting
   app.use(

--- a/packages/server/src/routes/providers.ts
+++ b/packages/server/src/routes/providers.ts
@@ -1,0 +1,135 @@
+// Provider Health API — monitor LLM provider availability and degradation
+// Auto-detects status from error rates: healthy / degraded / down
+
+import { Hono } from "hono";
+
+import type { MemoryStore } from "../storage/memory.js";
+import type { OtlpSpan } from "../types.js";
+
+type ProviderStatus = "healthy" | "degraded" | "down" | "no_data";
+
+interface ProviderHealth {
+  readonly provider: string;
+  readonly status: ProviderStatus;
+  readonly errorRate: number;
+  readonly totalRequests: number;
+  readonly totalErrors: number;
+  readonly rateLimitErrors: number;
+  readonly timeoutErrors: number;
+}
+
+const DEGRADED_THRESHOLD = 0.1; // 10% error rate
+const DOWN_THRESHOLD = 0.5; // 50% error rate
+
+function getAttrString(span: OtlpSpan, key: string): string | undefined {
+  const attr = span.attributes?.find((a) => a.key === key);
+  return attr?.value.stringValue;
+}
+
+function classifyError(errorType: string): "rate_limit" | "timeout" | "other" {
+  const lower = errorType.toLowerCase();
+  if (
+    lower.includes("rate_limit") ||
+    lower.includes("429") ||
+    lower.includes("quota")
+  ) {
+    return "rate_limit";
+  }
+  if (
+    lower.includes("timeout") ||
+    lower.includes("timed out") ||
+    lower.includes("deadline")
+  ) {
+    return "timeout";
+  }
+  return "other";
+}
+
+function determineStatus(
+  errorRate: number,
+  rateLimitRate: number,
+  timeoutRate: number,
+): ProviderStatus {
+  if (timeoutRate > DOWN_THRESHOLD) return "down";
+  if (errorRate > DOWN_THRESHOLD) return "down";
+  if (rateLimitRate > DEGRADED_THRESHOLD) return "degraded";
+  if (errorRate > DEGRADED_THRESHOLD) return "degraded";
+  return "healthy";
+}
+
+const PERIOD_MAP: Record<string, number> = {
+  "5m": 5 * 60 * 1000,
+  "15m": 15 * 60 * 1000,
+  "1h": 60 * 60 * 1000,
+  "1d": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+export function createProviderRoutes(store: MemoryStore) {
+  const app = new Hono();
+
+  // GET /api/providers/health?period=5m
+  app.get("/api/providers/health", (c) => {
+    const period = c.req.query("period") ?? "5m";
+    const periodMs = PERIOD_MAP[period];
+
+    if (periodMs === undefined) {
+      return c.json(
+        {
+          error: `Invalid period. Valid: ${Object.keys(PERIOD_MAP).join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const allSpans = store.querySpans("", periodMs);
+
+    // Group by provider
+    const byProvider = new Map<string, OtlpSpan[]>();
+    for (const span of allSpans) {
+      const provider = getAttrString(span, "gen_ai.provider.name") ?? "unknown";
+      const list = byProvider.get(provider);
+      if (list) {
+        list.push(span);
+      } else {
+        byProvider.set(provider, [span]);
+      }
+    }
+
+    const providers: ProviderHealth[] = [...byProvider.entries()].map(
+      ([provider, spans]) => {
+        const errors = spans.filter(
+          (s) => getAttrString(s, "gen_ai.toad_eye.status") === "error",
+        );
+        const rateLimitErrors = errors.filter((s) => {
+          const errType = getAttrString(s, "error.type") ?? "";
+          return classifyError(errType) === "rate_limit";
+        }).length;
+        const timeoutErrors = errors.filter((s) => {
+          const errType = getAttrString(s, "error.type") ?? "";
+          return classifyError(errType) === "timeout";
+        }).length;
+
+        const errorRate = spans.length > 0 ? errors.length / spans.length : 0;
+        const rateLimitRate =
+          spans.length > 0 ? rateLimitErrors / spans.length : 0;
+        const timeoutRate = spans.length > 0 ? timeoutErrors / spans.length : 0;
+
+        return {
+          provider,
+          status: determineStatus(errorRate, rateLimitRate, timeoutRate),
+          errorRate: Number(errorRate.toFixed(4)),
+          totalRequests: spans.length,
+          totalErrors: errors.length,
+          rateLimitErrors,
+          timeoutErrors,
+        };
+      },
+    );
+
+    return c.json({ period, providers });
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary
Monitor LLM provider health from error patterns. Auto-classifies providers as healthy / degraded / down.

## How it works
```
Error rate < 10%   → HEALTHY (green)
Error rate 10-50%  → DEGRADED (yellow) — rate limits, partial outage
Error rate > 50%   → DOWN (red) — timeouts, full outage
```

```bash
curl -H "Authorization: Bearer toad_xxx" \
  "http://localhost:4319/api/providers/health?period=5m"
```

```json
{
  "period": "5m",
  "providers": [
    { "provider": "openai", "status": "healthy", "errorRate": 0.02, "totalRequests": 150 },
    { "provider": "anthropic", "status": "degraded", "errorRate": 0.15, "rateLimitErrors": 12 }
  ]
}
```

## Grafana dashboard (7th)
- Provider status indicator with color-coded HEALTHY/DEGRADED/DOWN
- Request volume + error rate timeseries per provider
- Error breakdown by type (rate_limit vs timeout vs other)
- Uptime table (24h / 7d availability %)

## Test plan
- [x] 44/44 server tests passing (6 new)
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)