### PR TITLE
perf: stream accumulator — eliminate chunk storage memory leak (#105)

### DIFF
--- a/packages/instrumentation/src/__tests__/streaming.test.ts
+++ b/packages/instrumentation/src/__tests__/streaming.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 
-// Test the stream wrapping logic, extractors, and message parsing
+import type { StreamAccumulator } from "../instrumentations/types.js";
+
+// Test the accumulator-based stream extraction and message parsing
+
+function freshAcc(): StreamAccumulator {
+  return { completion: "", inputTokens: 0, outputTokens: 0 };
+}
 
 describe("OpenAI multi-modal extraction (#98)", () => {
-  // Inline the same logic as openai.ts extractMessages
   function extractMessages(messages: unknown): string {
     if (!Array.isArray(messages)) return "";
     return messages
@@ -27,8 +32,7 @@ describe("OpenAI multi-modal extraction (#98)", () => {
   }
 
   it("extracts plain string content", () => {
-    const result = extractMessages([{ content: "Hello world" }]);
-    expect(result).toBe("Hello world");
+    expect(extractMessages([{ content: "Hello world" }])).toBe("Hello world");
   });
 
   it("extracts text from ContentPart array", () => {
@@ -45,9 +49,7 @@ describe("OpenAI multi-modal extraction (#98)", () => {
 
   it("handles image-only messages", () => {
     const result = extractMessages([
-      {
-        content: [{ type: "image_url", image_url: { url: "https://..." } }],
-      },
+      { content: [{ type: "image_url", image_url: { url: "https://..." } }] },
     ]);
     expect(result).toBe("[image]");
   });
@@ -79,101 +81,134 @@ describe("OpenAI multi-modal extraction (#98)", () => {
   });
 });
 
-describe("OpenAI stream extraction", () => {
-  it("accumulates content from delta chunks", async () => {
-    // Simulate OpenAI extractStreamResponse
-    const { extractStreamResponse } = await getOpenAIExtractor();
+describe("OpenAI stream accumulator", () => {
+  function accumulateChunk(acc: StreamAccumulator, chunk: unknown) {
+    const c = chunk as {
+      choices?: { delta?: { content?: string } }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const delta = c?.choices?.[0]?.delta?.content;
+    if (delta) acc.completion += delta;
+    if (c?.usage) {
+      acc.inputTokens = c.usage.prompt_tokens ?? acc.inputTokens;
+      acc.outputTokens = c.usage.completion_tokens ?? acc.outputTokens;
+    }
+  }
 
-    const chunks = [
-      { choices: [{ delta: { content: "Hello" } }] },
-      { choices: [{ delta: { content: " world" } }] },
-      {
-        choices: [{ delta: {} }],
-        usage: { prompt_tokens: 10, completion_tokens: 5 },
-      },
-    ];
+  it("accumulates content from delta chunks", () => {
+    const acc = freshAcc();
+    accumulateChunk(acc, { choices: [{ delta: { content: "Hello" } }] });
+    accumulateChunk(acc, { choices: [{ delta: { content: " world" } }] });
+    accumulateChunk(acc, {
+      choices: [{ delta: {} }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
 
-    const result = extractStreamResponse!(chunks);
-    expect(result.completion).toBe("Hello world");
-    expect(result.inputTokens).toBe(10);
-    expect(result.outputTokens).toBe(5);
+    expect(acc.completion).toBe("Hello world");
+    expect(acc.inputTokens).toBe(10);
+    expect(acc.outputTokens).toBe(5);
   });
 
-  it("handles chunks without usage data", async () => {
-    const { extractStreamResponse } = await getOpenAIExtractor();
+  it("handles chunks without usage data", () => {
+    const acc = freshAcc();
+    accumulateChunk(acc, { choices: [{ delta: { content: "Hi" } }] });
+    accumulateChunk(acc, { choices: [{ delta: {} }] });
 
-    const chunks = [
-      { choices: [{ delta: { content: "Hi" } }] },
-      { choices: [{ delta: {} }] },
-    ];
-
-    const result = extractStreamResponse!(chunks);
-    expect(result.completion).toBe("Hi");
-    expect(result.inputTokens).toBe(0);
-    expect(result.outputTokens).toBe(0);
+    expect(acc.completion).toBe("Hi");
+    expect(acc.inputTokens).toBe(0);
+    expect(acc.outputTokens).toBe(0);
   });
 
-  it("handles empty stream", async () => {
-    const { extractStreamResponse } = await getOpenAIExtractor();
-    const result = extractStreamResponse!([]);
-    expect(result.completion).toBe("");
-    expect(result.inputTokens).toBe(0);
+  it("does not store raw chunk objects", () => {
+    const acc = freshAcc();
+    const bigChunk = {
+      choices: [{ delta: { content: "x" } }],
+      metadata: { large: "object" },
+    };
+    accumulateChunk(acc, bigChunk);
+
+    // acc only has primitives, no reference to bigChunk
+    expect(Object.keys(acc)).toEqual([
+      "completion",
+      "inputTokens",
+      "outputTokens",
+    ]);
   });
 });
 
-describe("Anthropic stream extraction", () => {
-  it("accumulates content from content_block_delta events", async () => {
-    const { extractStreamResponse } = await getAnthropicExtractor();
+describe("Anthropic stream accumulator", () => {
+  function accumulateChunk(acc: StreamAccumulator, chunk: unknown) {
+    const event = chunk as {
+      type?: string;
+      message?: { usage?: { input_tokens?: number } };
+      delta?: { text?: string };
+      usage?: { output_tokens?: number };
+    };
+    if (event.type === "content_block_delta" && event.delta?.text) {
+      acc.completion += event.delta.text;
+    }
+    if (event.type === "message_start" && event.message?.usage) {
+      acc.inputTokens = event.message.usage.input_tokens ?? 0;
+    }
+    if (event.type === "message_delta" && event.usage) {
+      acc.outputTokens = event.usage.output_tokens ?? 0;
+    }
+  }
 
-    const chunks = [
-      { type: "message_start", message: { usage: { input_tokens: 15 } } },
-      { type: "content_block_delta", delta: { text: "Hello" } },
-      { type: "content_block_delta", delta: { text: " from Claude" } },
-      { type: "message_delta", usage: { output_tokens: 8 } },
-      { type: "message_stop" },
-    ];
+  it("accumulates content from content_block_delta events", () => {
+    const acc = freshAcc();
+    accumulateChunk(acc, {
+      type: "message_start",
+      message: { usage: { input_tokens: 15 } },
+    });
+    accumulateChunk(acc, {
+      type: "content_block_delta",
+      delta: { text: "Hello" },
+    });
+    accumulateChunk(acc, {
+      type: "content_block_delta",
+      delta: { text: " from Claude" },
+    });
+    accumulateChunk(acc, {
+      type: "message_delta",
+      usage: { output_tokens: 8 },
+    });
+    accumulateChunk(acc, { type: "message_stop" });
 
-    const result = extractStreamResponse!(chunks);
-    expect(result.completion).toBe("Hello from Claude");
-    expect(result.inputTokens).toBe(15);
-    expect(result.outputTokens).toBe(8);
-  });
-
-  it("handles empty stream", async () => {
-    const { extractStreamResponse } = await getAnthropicExtractor();
-    const result = extractStreamResponse!([]);
-    expect(result.completion).toBe("");
-    expect(result.inputTokens).toBe(0);
+    expect(acc.completion).toBe("Hello from Claude");
+    expect(acc.inputTokens).toBe(15);
+    expect(acc.outputTokens).toBe(8);
   });
 });
 
 describe("stream wrapping (async iterable)", () => {
-  it("wraps async iterable transparently", async () => {
+  it("wraps async iterable with accumulator", async () => {
     async function* mockStream() {
-      yield { data: "chunk1" };
-      yield { data: "chunk2" };
-      yield { data: "chunk3" };
+      yield { n: 1 };
+      yield { n: 2 };
+      yield { n: 3 };
     }
 
-    const collected: unknown[] = [];
-    let completeCalled = false;
+    let completeAcc: StreamAccumulator | null = null;
 
-    // Inline wrapper matching the logic in create.ts
     async function* wrapStream<T>(
       stream: AsyncIterable<T>,
-      onComplete: (chunks: T[]) => void,
+      onComplete: (acc: StreamAccumulator) => void,
     ) {
-      const chunks: T[] = [];
+      const acc: StreamAccumulator = {
+        completion: "",
+        inputTokens: 0,
+        outputTokens: 0,
+      };
       for await (const chunk of stream) {
-        chunks.push(chunk);
+        acc.completion += String((chunk as { n: number }).n);
         yield chunk;
       }
-      onComplete(chunks);
+      onComplete(acc);
     }
 
-    const wrapped = wrapStream(mockStream(), (chunks) => {
-      completeCalled = true;
-      collected.push(...chunks);
+    const wrapped = wrapStream(mockStream(), (acc) => {
+      completeAcc = acc;
     });
 
     const results: unknown[] = [];
@@ -182,8 +217,8 @@ describe("stream wrapping (async iterable)", () => {
     }
 
     expect(results).toHaveLength(3);
-    expect(completeCalled).toBe(true);
-    expect(collected).toHaveLength(3);
+    expect(completeAcc).not.toBeNull();
+    expect(completeAcc!.completion).toBe("123");
   });
 
   it("propagates errors from stream", async () => {
@@ -210,61 +245,3 @@ describe("stream wrapping (async iterable)", () => {
     expect(results).toHaveLength(1);
   });
 });
-
-// Helpers to get extractors without loading real SDKs
-async function getOpenAIExtractor() {
-  // We can't import the openai.ts file directly because it tries to register.
-  // Instead, test the extraction logic inline (same code as in openai.ts)
-  return {
-    extractStreamResponse: (chunks: unknown[]) => {
-      let completion = "";
-      let inputTokens = 0;
-      let outputTokens = 0;
-
-      for (const chunk of chunks) {
-        const c = chunk as {
-          choices?: { delta?: { content?: string } }[];
-          usage?: { prompt_tokens?: number; completion_tokens?: number };
-        };
-        const delta = c?.choices?.[0]?.delta?.content;
-        if (delta) completion += delta;
-        if (c?.usage) {
-          inputTokens = c.usage.prompt_tokens ?? inputTokens;
-          outputTokens = c.usage.completion_tokens ?? outputTokens;
-        }
-      }
-
-      return { completion, inputTokens, outputTokens };
-    },
-  };
-}
-
-async function getAnthropicExtractor() {
-  return {
-    extractStreamResponse: (chunks: unknown[]) => {
-      let completion = "";
-      let inputTokens = 0;
-      let outputTokens = 0;
-
-      for (const chunk of chunks) {
-        const event = chunk as {
-          type?: string;
-          message?: { usage?: { input_tokens?: number } };
-          delta?: { text?: string };
-          usage?: { output_tokens?: number };
-        };
-        if (event.type === "content_block_delta" && event.delta?.text) {
-          completion += event.delta.text;
-        }
-        if (event.type === "message_start" && event.message?.usage) {
-          inputTokens = event.message.usage.input_tokens ?? 0;
-        }
-        if (event.type === "message_delta" && event.usage) {
-          outputTokens = event.usage.output_tokens ?? 0;
-        }
-      }
-
-      return { completion, inputTokens, outputTokens };
-    },
-  };
-}

--- a/packages/instrumentation/src/instrumentations/anthropic.ts
+++ b/packages/instrumentation/src/instrumentations/anthropic.ts
@@ -51,31 +51,22 @@ const messagesCreate: PatchTarget = {
     };
   },
   isStreaming: (body) => !!(body as { stream?: boolean })?.stream,
-  extractStreamResponse: (chunks) => {
-    // Anthropic stream events: message_start, content_block_delta, message_delta, message_stop
-    let completion = "";
-    let inputTokens = 0;
-    let outputTokens = 0;
-
-    for (const chunk of chunks) {
-      const event = chunk as {
-        type?: string;
-        message?: { usage?: { input_tokens?: number } };
-        delta?: { text?: string; usage?: { output_tokens?: number } };
-        usage?: { output_tokens?: number };
-      };
-      if (event.type === "content_block_delta" && event.delta?.text) {
-        completion += event.delta.text;
-      }
-      if (event.type === "message_start" && event.message?.usage) {
-        inputTokens = event.message.usage.input_tokens ?? 0;
-      }
-      if (event.type === "message_delta" && event.usage) {
-        outputTokens = event.usage.output_tokens ?? 0;
-      }
+  accumulateChunk: (acc, chunk) => {
+    const event = chunk as {
+      type?: string;
+      message?: { usage?: { input_tokens?: number } };
+      delta?: { text?: string };
+      usage?: { output_tokens?: number };
+    };
+    if (event.type === "content_block_delta" && event.delta?.text) {
+      acc.completion += event.delta.text;
     }
-
-    return { completion, inputTokens, outputTokens };
+    if (event.type === "message_start" && event.message?.usage) {
+      acc.inputTokens = event.message.usage.input_tokens ?? 0;
+    }
+    if (event.type === "message_delta" && event.usage) {
+      acc.outputTokens = event.usage.output_tokens ?? 0;
+    }
   },
 };
 

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -18,7 +18,11 @@ import {
 } from "../core/metrics.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "../types/index.js";
 import type { LLMProvider } from "../types/index.js";
-import type { Instrumentation, PatchTarget } from "./types.js";
+import type {
+  Instrumentation,
+  PatchTarget,
+  StreamAccumulator,
+} from "./types.js";
 
 const require = createRequire(import.meta.url);
 
@@ -46,24 +50,27 @@ function loadModule(moduleName: string): any {
 }
 
 /**
- * Wrap an async iterable stream to intercept chunks.
- * Yields every chunk transparently to the caller while collecting them.
- * On stream end, calls onComplete with all accumulated chunks.
+ * Wrap an async iterable stream with an accumulator.
+ * Yields every chunk transparently. Accumulates only extracted data (no raw chunks stored).
+ * On stream end, calls onComplete with the accumulated result.
  */
 async function* wrapAsyncIterable<T>(
   stream: AsyncIterable<T>,
-  onChunk: (chunk: T) => void,
-  onComplete: (chunks: T[]) => void,
+  accumulate: (acc: StreamAccumulator, chunk: T) => void,
+  onComplete: (acc: StreamAccumulator) => void,
   onError: (err: unknown) => void,
 ): AsyncGenerator<T> {
-  const chunks: T[] = [];
+  const acc: StreamAccumulator = {
+    completion: "",
+    inputTokens: 0,
+    outputTokens: 0,
+  };
   try {
     for await (const chunk of stream) {
-      chunks.push(chunk);
-      onChunk(chunk);
+      accumulate(acc, chunk);
       yield chunk;
     }
-    onComplete(chunks);
+    onComplete(acc);
   } catch (err) {
     onError(err);
     throw err;
@@ -87,7 +94,6 @@ function createStreamingHandler(
     const start = performance.now();
     const response = await original.call(thisArg, body, ...rest);
 
-    // Use startActiveSpan to preserve parent-child context (e.g. inside traceAgentQuery)
     const span: Span = tracer.startSpan(`gen_ai.${providerName}.${req.model}`);
     const ctx = trace.setSpan(context.active(), span);
 
@@ -102,20 +108,19 @@ function createStreamingHandler(
       ctx,
       wrapAsyncIterable(
         response as AsyncIterable<unknown>,
-        () => {},
-        (chunks) => {
+        (acc, chunk) => patch.accumulateChunk!(acc, chunk),
+        (acc) => {
           const duration = performance.now() - start;
-          const res = patch.extractStreamResponse!(chunks);
           const cost = calculateCost(
             req.model,
-            res.inputTokens,
-            res.outputTokens,
+            acc.inputTokens,
+            acc.outputTokens,
           );
 
           span.setAttributes({
             [GEN_AI_ATTRS.RESPONSE_MODEL]: req.model,
-            [GEN_AI_ATTRS.INPUT_TOKENS]: res.inputTokens,
-            [GEN_AI_ATTRS.OUTPUT_TOKENS]: res.outputTokens,
+            [GEN_AI_ATTRS.INPUT_TOKENS]: acc.inputTokens,
+            [GEN_AI_ATTRS.OUTPUT_TOKENS]: acc.outputTokens,
             [GEN_AI_ATTRS.COST]: cost,
             [GEN_AI_ATTRS.STATUS]: "success",
           });
@@ -126,7 +131,7 @@ function createStreamingHandler(
           recordRequestDuration(duration, providerName, req.model);
           recordRequestCost(cost, providerName, req.model);
           recordTokens(
-            res.inputTokens + res.outputTokens,
+            acc.inputTokens + acc.outputTokens,
             providerName,
             req.model,
           );
@@ -148,8 +153,6 @@ function createStreamingHandler(
       ),
     );
 
-    // Return an object that looks like the original stream but with our wrapper
-    // Preserve the original object shape — SDKs may have extra methods/properties
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const proxy = Object.create(response as any);
     proxy[Symbol.asyncIterator] = () => wrapped[Symbol.asyncIterator]();
@@ -164,7 +167,7 @@ function createPatchedMethod(
   providerName: LLMProvider,
 ) {
   const streamHandler =
-    patch.isStreaming && patch.extractStreamResponse
+    patch.isStreaming && patch.accumulateChunk
       ? createStreamingHandler(original, patch, providerName)
       : null;
 
@@ -177,7 +180,6 @@ function createPatchedMethod(
       return original.call(this, body, ...rest);
     }
 
-    // Handle streaming calls
     if (streamHandler && patch.isStreaming?.(body)) {
       return streamHandler(this, body, rest);
     }
@@ -206,10 +208,6 @@ function createPatchedMethod(
   };
 }
 
-/**
- * Factory for creating SDK instrumentations.
- * Eliminates boilerplate: SDK resolution, prototype patching, error handling, cleanup.
- */
 export function createInstrumentation(config: {
   name: LLMProvider;
   moduleName: string;

--- a/packages/instrumentation/src/instrumentations/openai.ts
+++ b/packages/instrumentation/src/instrumentations/openai.ts
@@ -49,27 +49,17 @@ const chatCompletions: PatchTarget = {
     };
   },
   isStreaming: (body) => !!(body as { stream?: boolean })?.stream,
-  extractStreamResponse: (chunks) => {
-    // OpenAI stream chunks: { choices: [{ delta: { content } }], usage?: { ... } }
-    let completion = "";
-    let inputTokens = 0;
-    let outputTokens = 0;
-
-    for (const chunk of chunks) {
-      const c = chunk as {
-        choices?: { delta?: { content?: string } }[];
-        usage?: { prompt_tokens?: number; completion_tokens?: number };
-      };
-      const delta = c?.choices?.[0]?.delta?.content;
-      if (delta) completion += delta;
-      // Usage is typically in the final chunk (when stream_options.include_usage is set)
-      if (c?.usage) {
-        inputTokens = c.usage.prompt_tokens ?? inputTokens;
-        outputTokens = c.usage.completion_tokens ?? outputTokens;
-      }
+  accumulateChunk: (acc, chunk) => {
+    const c = chunk as {
+      choices?: { delta?: { content?: string } }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const delta = c?.choices?.[0]?.delta?.content;
+    if (delta) acc.completion += delta;
+    if (c?.usage) {
+      acc.inputTokens = c.usage.prompt_tokens ?? acc.inputTokens;
+      acc.outputTokens = c.usage.completion_tokens ?? acc.outputTokens;
     }
-
-    return { completion, inputTokens, outputTokens };
   },
 };
 

--- a/packages/instrumentation/src/instrumentations/types.ts
+++ b/packages/instrumentation/src/instrumentations/types.ts
@@ -8,6 +8,13 @@ export interface Instrumentation {
   disable(): void;
 }
 
+/** Accumulated stream data — only primitives, no raw SDK objects. */
+export interface StreamAccumulator {
+  completion: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
 /** Describes a single method to monkey-patch on an SDK prototype. */
 export interface PatchTarget {
   /** How to find the prototype from the loaded SDK module */
@@ -34,10 +41,6 @@ export interface PatchTarget {
   shouldSkip?: (body: unknown) => boolean;
   /** Return true if this call is a streaming request */
   isStreaming?: (body: unknown) => boolean;
-  /** Extract final stats from accumulated stream chunks. Required when isStreaming is set. */
-  extractStreamResponse?: (chunks: unknown[]) => {
-    completion: string;
-    inputTokens: number;
-    outputTokens: number;
-  };
+  /** Process one stream chunk — extract only the data we need into the accumulator. */
+  accumulateChunk?: (acc: StreamAccumulator, chunk: unknown) => void;
 }


### PR DESCRIPTION
## Summary
Stream wrapper no longer stores raw SDK chunk objects. Uses accumulator pattern — only completion string and token counts are kept in memory.

## Before vs After
```
Before: chunks.push(rawChunkObject)  → O(N) complex objects in memory
After:  acc.completion += delta       → O(1) primitive accumulator
```

## API change (internal)
```typescript
// Before (PatchTarget):
extractStreamResponse: (chunks: unknown[]) => { completion, inputTokens, outputTokens }

// After:
accumulateChunk: (acc: StreamAccumulator, chunk: unknown) => void
```

`StreamAccumulator` is a simple `{ completion: string, inputTokens: number, outputTokens: number }`.

## Test plan
- [x] 115/115 tests passing
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)