### PR TITLE
feat: TTFT metric — Time To First Token for streaming (#103)

### DIFF
--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -16,6 +16,7 @@ let agentToolUsage: Counter;
 let guardEvaluations: Counter;
 let guardWouldBlock: Counter;
 let semanticDrift: Histogram;
+let timeToFirstToken: Histogram;
 let budgetExceeded: Counter;
 let budgetBlocked: Counter;
 let budgetDowngraded: Counter;
@@ -71,6 +72,11 @@ export function initMetrics() {
   semanticDrift = meter.createHistogram(GEN_AI_METRICS.SEMANTIC_DRIFT, {
     description:
       "Semantic drift from baseline (0 = identical, 1 = completely different)",
+  });
+
+  timeToFirstToken = meter.createHistogram(GEN_AI_METRICS.TIME_TO_FIRST_TOKEN, {
+    description: "Time from request start to first streaming token (ms)",
+    unit: "ms",
   });
 
   budgetExceeded = meter.createCounter(GEN_AI_METRICS.BUDGET_EXCEEDED, {
@@ -172,6 +178,17 @@ export function recordSemanticDrift(
   model: string,
 ) {
   semanticDrift.record(drift, {
+    [GEN_AI_ATTRS.PROVIDER]: provider,
+    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
+  });
+}
+
+export function recordTimeToFirstToken(
+  ms: number,
+  provider: string,
+  model: string,
+) {
+  timeToFirstToken.record(ms, {
     [GEN_AI_ATTRS.PROVIDER]: provider,
     [GEN_AI_ATTRS.REQUEST_MODEL]: model,
   });

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -15,6 +15,7 @@ import {
   recordTokens,
   recordRequest,
   recordError,
+  recordTimeToFirstToken,
 } from "../core/metrics.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "../types/index.js";
 import type { LLMProvider } from "../types/index.js";
@@ -53,10 +54,12 @@ function loadModule(moduleName: string): any {
  * Wrap an async iterable stream with an accumulator.
  * Yields every chunk transparently. Accumulates only extracted data (no raw chunks stored).
  * On stream end, calls onComplete with the accumulated result.
+ * onFirstChunk is called once when the first chunk arrives (for TTFT tracking).
  */
 async function* wrapAsyncIterable<T>(
   stream: AsyncIterable<T>,
   accumulate: (acc: StreamAccumulator, chunk: T) => void,
+  onFirstChunk: () => void,
   onComplete: (acc: StreamAccumulator) => void,
   onError: (err: unknown) => void,
 ): AsyncGenerator<T> {
@@ -65,8 +68,13 @@ async function* wrapAsyncIterable<T>(
     inputTokens: 0,
     outputTokens: 0,
   };
+  let firstChunk = true;
   try {
     for await (const chunk of stream) {
+      if (firstChunk) {
+        onFirstChunk();
+        firstChunk = false;
+      }
       accumulate(acc, chunk);
       yield chunk;
     }
@@ -109,6 +117,10 @@ function createStreamingHandler(
       wrapAsyncIterable(
         response as AsyncIterable<unknown>,
         (acc, chunk) => patch.accumulateChunk!(acc, chunk),
+        () => {
+          const ttft = performance.now() - start;
+          recordTimeToFirstToken(ttft, providerName, req.model);
+        },
         (acc) => {
           const duration = performance.now() - start;
           const cost = calculateCost(

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -20,6 +20,8 @@ export const GEN_AI_METRICS = {
   GUARD_WOULD_BLOCK: "gen_ai.toad_eye.guard.would_block",
   // Drift metrics
   SEMANTIC_DRIFT: "gen_ai.toad_eye.semantic_drift",
+  // Streaming metrics
+  TIME_TO_FIRST_TOKEN: "gen_ai.client.time_to_first_token",
   // Budget metrics
   BUDGET_EXCEEDED: "gen_ai.toad_eye.budget.exceeded",
   BUDGET_BLOCKED: "gen_ai.toad_eye.budget.blocked",


### PR DESCRIPTION
## Summary
New `gen_ai.client.time_to_first_token` histogram metric — records the time from request start to first streaming chunk received.

Previously, streaming latency was mixed with total stream duration in the same histogram. A 30s stream and a 1s regular request looked the same in p95. Now they're separated:
- **TTFT** = how long until user sees first word (what matters for UX)
- **Total duration** = full stream time (existing metric, unchanged)

## How it works
```
Stream start (performance.now())
    ↓ ... waiting for first chunk ...
    ↓ onFirstChunk() → recordTimeToFirstToken(ttft)  ← NEW
    ↓ ... more chunks ...
    ↓ onComplete() → recordRequestDuration(total)     ← existing
```

## Files changed
- `types/metrics.ts` — new `TIME_TO_FIRST_TOKEN` constant
- `core/metrics.ts` — `recordTimeToFirstToken()` function + histogram init
- `instrumentations/create.ts` — `onFirstChunk` callback in `wrapAsyncIterable`

## Test plan
- [x] 115/115 tests passing
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)