### PR TITLE
feat: Gemini streaming instrumentation — generateContentStream (#104)

### DIFF
--- a/packages/instrumentation/src/__tests__/streaming.test.ts
+++ b/packages/instrumentation/src/__tests__/streaming.test.ts
@@ -181,6 +181,54 @@ describe("Anthropic stream accumulator", () => {
   });
 });
 
+describe("Gemini stream accumulator (#104)", () => {
+  function accumulateChunk(acc: StreamAccumulator, chunk: unknown) {
+    const c = chunk as {
+      text?: () => string;
+      usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+      };
+    };
+    try {
+      const text = c?.text?.();
+      if (text) acc.completion += text;
+    } catch {
+      // text() may throw
+    }
+    if (c?.usageMetadata) {
+      acc.inputTokens = c.usageMetadata.promptTokenCount ?? acc.inputTokens;
+      acc.outputTokens =
+        c.usageMetadata.candidatesTokenCount ?? acc.outputTokens;
+    }
+  }
+
+  it("accumulates text from Gemini stream chunks", () => {
+    const acc = freshAcc();
+    accumulateChunk(acc, { text: () => "Hello " });
+    accumulateChunk(acc, { text: () => "from Gemini" });
+    accumulateChunk(acc, {
+      text: () => "",
+      usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 12 },
+    });
+
+    expect(acc.completion).toBe("Hello from Gemini");
+    expect(acc.inputTokens).toBe(20);
+    expect(acc.outputTokens).toBe(12);
+  });
+
+  it("handles text() throwing (blocked content)", () => {
+    const acc = freshAcc();
+    accumulateChunk(acc, {
+      text: () => {
+        throw new Error("Content blocked");
+      },
+    });
+
+    expect(acc.completion).toBe("");
+  });
+});
+
 describe("stream wrapping (async iterable)", () => {
   it("wraps async iterable with accumulator", async () => {
     async function* mockStream() {

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -112,10 +112,23 @@ function createStreamingHandler(
       [GEN_AI_ATTRS.OPERATION]: "chat",
     });
 
+    // Some SDKs (Gemini) return { stream: AsyncIterable } instead of a direct AsyncIterable
+    const resp = response as Record<string, unknown>;
+    const hasStreamProp =
+      resp != null &&
+      typeof resp === "object" &&
+      "stream" in resp &&
+      resp["stream"] != null &&
+      typeof resp["stream"] === "object" &&
+      Symbol.asyncIterator in (resp["stream"] as object);
+    const streamIterable = hasStreamProp
+      ? (resp["stream"] as AsyncIterable<unknown>)
+      : (response as AsyncIterable<unknown>);
+
     const wrapped = context.bind(
       ctx,
       wrapAsyncIterable(
-        response as AsyncIterable<unknown>,
+        streamIterable,
         (acc, chunk) => patch.accumulateChunk!(acc, chunk),
         () => {
           const ttft = performance.now() - start;

--- a/packages/instrumentation/src/instrumentations/gemini.ts
+++ b/packages/instrumentation/src/instrumentations/gemini.ts
@@ -23,7 +23,6 @@ const generateContent: PatchTarget = {
   extractRequest(body) {
     return {
       prompt: extractPrompt(body),
-      // model comes from `this.model` — injected by create.ts via the patched function's `this`
       model: "unknown",
     };
   },
@@ -51,10 +50,49 @@ const generateContent: PatchTarget = {
   },
 };
 
+const generateContentStream: PatchTarget = {
+  getPrototype: (sdk) => sdk?.GenerativeModel?.prototype,
+  method: "generateContentStream",
+  extractRequest(body) {
+    return {
+      prompt: extractPrompt(body),
+      model: "unknown",
+    };
+  },
+  extractResponse: () => ({
+    completion: "",
+    inputTokens: 0,
+    outputTokens: 0,
+  }),
+  // generateContentStream always returns a stream
+  isStreaming: () => true,
+  accumulateChunk: (acc, chunk) => {
+    // Gemini stream chunks are GenerateContentResponse objects
+    const c = chunk as {
+      text?: () => string;
+      usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+      };
+    };
+    try {
+      const text = c?.text?.();
+      if (text) acc.completion += text;
+    } catch {
+      // text() may throw if content is blocked
+    }
+    if (c?.usageMetadata) {
+      acc.inputTokens = c.usageMetadata.promptTokenCount ?? acc.inputTokens;
+      acc.outputTokens =
+        c.usageMetadata.candidatesTokenCount ?? acc.outputTokens;
+    }
+  },
+};
+
 register(
   createInstrumentation({
     name: "gemini",
     moduleName: "@google/generative-ai",
-    patches: [generateContent],
+    patches: [generateContent, generateContentStream],
   }),
 );


### PR DESCRIPTION
## Summary
Gemini's `generateContentStream` was the last unmonitored streaming method. Now all three SDKs have full streaming support.

## All streaming support complete
| SDK | Method | Status |
|-----|--------|--------|
| OpenAI | `chat.completions.create({ stream: true })` | Done (#93) |
| Anthropic | `messages.create({ stream: true })` | Done (#93) |
| **Gemini** | **`generateContentStream()`** | **Done (this PR)** |

## Gemini-specific handling
- `generateContentStream` returns `{ stream: AsyncIterable }` (not a direct iterable)
- Stream wrapper auto-detects and unwraps `.stream` property
- Each chunk has `.text()` method (may throw on blocked content — handled)
- Token counts from `usageMetadata.promptTokenCount` / `candidatesTokenCount`

## Test plan
- [x] 117/117 tests passing (2 new Gemini streaming tests)
- [x] TypeScript strict mode — clean
- [x] Prettier — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)