### PR TITLE
fix: edge case handling — NaN config, payload limits, drift timeout (#115)

### DIFF
--- a/packages/instrumentation/src/__tests__/export.test.ts
+++ b/packages/instrumentation/src/__tests__/export.test.ts
@@ -160,7 +160,7 @@ describe("traceToEvalYaml", () => {
 
     expect(assertions).toContainEqual({
       type: "not_contains",
-      value: "I cannot",
+      value: "i cannot",
     });
   });
 

--- a/packages/instrumentation/src/drift/monitor.ts
+++ b/packages/instrumentation/src/drift/monitor.ts
@@ -85,7 +85,13 @@ export function createDriftMonitor(config: DriftMonitorConfig): DriftMonitor {
     check: performCheck,
 
     checkInBackground(response, providerName, model) {
-      void performCheck(response, providerName, model).catch((err) => {
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Drift check timeout (5s)")), 5000),
+      );
+      void Promise.race([
+        performCheck(response, providerName, model),
+        timeout,
+      ]).catch((err) => {
         console.warn(
           `[toad-eye] Drift check failed (non-blocking): ${err instanceof Error ? err.message : String(err)}`,
         );

--- a/packages/instrumentation/src/export.ts
+++ b/packages/instrumentation/src/export.ts
@@ -96,7 +96,7 @@ function buildAssertions(completion: string | undefined): EvalAssertion[] {
     });
 
     if (!completion.toLowerCase().includes(REFUSAL_MARKER)) {
-      assertions.push({ type: "not_contains", value: "I cannot" });
+      assertions.push({ type: "not_contains", value: REFUSAL_MARKER });
     }
 
     if (isJson(completion)) {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -2,6 +2,18 @@
 
 import type { ServerConfig } from "./types.js";
 
+function parseIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `toad-eye server: invalid ${name}="${raw}" — must be a number`,
+    );
+  }
+  return parsed;
+}
+
 export function loadConfig(): ServerConfig {
   const apiKeysRaw = process.env["TOAD_API_KEYS"] ?? "";
   const apiKeys = apiKeysRaw
@@ -10,18 +22,17 @@ export function loadConfig(): ServerConfig {
     .filter((k) => k.length > 0);
 
   if (apiKeys.length === 0) {
-    // Generate a default key for development
     const devKey = "toad_dev_" + Math.random().toString(36).slice(2, 10);
     apiKeys.push(devKey);
     console.log(`No TOAD_API_KEYS set. Generated dev key: ${devKey}`);
   }
 
   return {
-    port: parseInt(process.env["PORT"] ?? "4319", 10),
+    port: parseIntEnv("PORT", 4319),
     apiKeys,
     rateLimit: {
-      windowMs: parseInt(process.env["RATE_LIMIT_WINDOW_MS"] ?? "60000", 10),
-      maxRequests: parseInt(process.env["RATE_LIMIT_MAX"] ?? "100", 10),
+      windowMs: parseIntEnv("RATE_LIMIT_WINDOW_MS", 60000),
+      maxRequests: parseIntEnv("RATE_LIMIT_MAX", 100),
     },
   };
 }

--- a/packages/server/src/routes/ingest.ts
+++ b/packages/server/src/routes/ingest.ts
@@ -27,7 +27,10 @@ export function createIngestRoutes(store: MemoryStore) {
     }
 
     const apiKey = extractApiKey(c.req.header("authorization"));
-    store.addTrace(apiKey, asTracePayload(body));
+    const accepted = store.addTrace(apiKey, asTracePayload(body));
+    if (!accepted) {
+      return c.json({ error: "Trace too large — too many spans" }, 413);
+    }
 
     return c.json({ status: "ok" });
   });

--- a/packages/server/src/storage/memory.ts
+++ b/packages/server/src/storage/memory.ts
@@ -20,9 +20,17 @@ export class MemoryStore {
     this.maxItems = maxItems;
   }
 
-  addTrace(apiKey: string, payload: OtlpTracePayload) {
+  addTrace(apiKey: string, payload: OtlpTracePayload): boolean {
+    // Guard against oversized payloads
+    let spanCount = 0;
+    for (const rs of payload.resourceSpans) {
+      for (const ss of rs.scopeSpans) {
+        spanCount += ss.spans.length;
+      }
+    }
+    if (spanCount > this.maxItems) return false;
+
     if (this.traces.length >= this.maxItems) {
-      // Drop oldest 10% when full
       const dropCount = Math.ceil(this.maxItems * 0.1);
       this.traces.splice(0, dropCount);
     }
@@ -32,6 +40,7 @@ export class MemoryStore {
       apiKey,
       payload,
     });
+    return true;
   }
 
   addMetrics(apiKey: string, payload: OtlpMetricsPayload) {


### PR DESCRIPTION
## Summary
6 edge case fixes from code audit (4 actual changes — 2 were already fixed in #114).

| Fix | What |
|-----|------|
| Config NaN | `PORT=abc` now throws instead of starting on port NaN |
| Payload limit | Traces with >10k spans rejected with 413 |
| Drift timeout | `checkInBackground` has 5s timeout via `Promise.race` |
| Refusal marker | Consistent lowercase constant usage in export.ts |

## Test plan
- [x] 117/117 instrumentation tests passing
- [x] 44/44 server tests passing
- [x] TypeScript strict mode — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)