### PR TITLE
fix: consistency — FINISH_REASONS, negative costs, JSON errors, tests (#116)

### DIFF
--- a/packages/instrumentation/src/core/pricing.ts
+++ b/packages/instrumentation/src/core/pricing.ts
@@ -59,6 +59,7 @@ export function calculateCost(
   inputTokens: number,
   outputTokens: number,
 ): number {
+  if (inputTokens < 0 || outputTokens < 0) return 0;
   const pricing = getModelPricing(model);
   if (!pricing) return 0;
 

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -157,6 +157,7 @@ function createStreamingHandler(
             [GEN_AI_ATTRS.OUTPUT_TOKENS]: acc.outputTokens,
             [GEN_AI_ATTRS.COST]: cost,
             [GEN_AI_ATTRS.STATUS]: "success",
+            [GEN_AI_ATTRS.FINISH_REASONS]: ["stop"],
           });
           span.setStatus({ code: SpanStatusCode.OK });
           span.end();

--- a/packages/server/src/__tests__/query.test.ts
+++ b/packages/server/src/__tests__/query.test.ts
@@ -276,3 +276,42 @@ describe("GET /api/query", () => {
     expect(body.spanCount).toBe(0);
   });
 });
+
+describe("auth required for /api/* routes", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    app = createApp(config).app;
+  });
+
+  it("rejects /api/errors without auth", async () => {
+    const res = await app.request("/api/errors?period=1d");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects /api/models/compare without auth", async () => {
+    const res = await app.request("/api/models/compare?models=gpt-4o");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects /api/query without auth", async () => {
+    const res = await app.request("/api/query");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("edge cases", () => {
+  let app: ReturnType<typeof createApp>["app"];
+
+  beforeEach(() => {
+    app = createApp(config).app;
+  });
+
+  it("handles empty models parameter gracefully", async () => {
+    const res = await app.request("/api/models/compare?models=&period=7d", {
+      headers: authHeaders(),
+    });
+    // Empty models param treated as missing — returns 400
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/routes/ingest.ts
+++ b/packages/server/src/routes/ingest.ts
@@ -16,7 +16,12 @@ export function createIngestRoutes(store: MemoryStore) {
 
   // POST /v1/traces — accept OTLP trace data
   app.post("/v1/traces", async (c) => {
-    const body = await c.req.json().catch(() => null);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
 
     const result = validateTracePayload(body);
     if (!result.valid) {
@@ -37,7 +42,12 @@ export function createIngestRoutes(store: MemoryStore) {
 
   // POST /v1/metrics — accept OTLP metrics data
   app.post("/v1/metrics", async (c) => {
-    const body = await c.req.json().catch(() => null);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
 
     const result = validateMetricsPayload(body);
     if (!result.valid) {


### PR DESCRIPTION
## Summary
Final batch of minor fixes from deep code audit.

| Fix | What |
|-----|------|
| FINISH_REASONS | Streaming spans now include `finish_reasons: ['stop']` like non-streaming |
| Negative costs | `calculateCost` returns 0 for negative token counts |
| JSON errors | Ingest routes return explicit 400 "Invalid JSON body" |
| Auth tests | 3 new 401 tests for /api/errors, /api/models/compare, /api/query |
| Edge case | Empty models param test |

## Test plan
- [x] 117/117 instrumentation tests passing
- [x] 48/48 server tests passing (4 new)
- [x] **165 total tests**

🐸 Generated with [Claude Code](https://claude.com/claude-code)