### PR TITLE
refactor: Proxy for stream wrapping + guard attrs on active span

### DIFF
--- a/packages/instrumentation/src/__tests__/guard.test.ts
+++ b/packages/instrumentation/src/__tests__/guard.test.ts
@@ -2,14 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockSpan = {
   setAttributes: vi.fn(),
-  end: vi.fn(),
 };
 
 vi.mock("@opentelemetry/api", () => ({
   trace: {
-    getTracer: () => ({
-      startSpan: (_name: string) => mockSpan,
-    }),
+    getActiveSpan: () => mockSpan,
   },
   metrics: { getMeter: () => ({}) },
   diag: { warn: vi.fn(), debug: vi.fn() },
@@ -32,7 +29,7 @@ describe("recordGuardResult", () => {
     vi.clearAllMocks();
   });
 
-  it("creates a span with guard attributes for passing result", () => {
+  it("sets guard attributes on active span for passing result", () => {
     recordGuardResult({
       mode: "shadow",
       passed: true,
@@ -44,7 +41,6 @@ describe("recordGuardResult", () => {
       "gen_ai.toad_eye.guard.passed": true,
       "gen_ai.toad_eye.guard.rule_name": "schema_check",
     });
-    expect(mockSpan.end).toHaveBeenCalled();
   });
 
   it("includes failure_reason when guard fails", () => {

--- a/packages/instrumentation/src/guard.ts
+++ b/packages/instrumentation/src/guard.ts
@@ -2,10 +2,9 @@
  * Shadow Guardrails integration — records toad-guard validation results
  * as span attributes and metrics without blocking LLM responses.
  *
- * toad-guard validates each LLM response and passes the result here.
- * In shadow mode, validation runs but never throws — results are recorded
- * for observability only, letting you tune guardrail thresholds on
- * production traffic before switching to enforce mode.
+ * Results are recorded as attributes on the currently active span
+ * (typically the LLM call span from traceLLMCall). This avoids
+ * trace bloat — no extra child spans per guard rule.
  *
  * Usage from toad-guard:
  * ```ts
@@ -18,35 +17,32 @@
 
 import { trace } from "@opentelemetry/api";
 import type { GuardResult } from "./types/index.js";
-import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
+import { GEN_AI_ATTRS } from "./types/index.js";
 import {
   recordGuardEvaluation,
   recordGuardWouldBlock,
 } from "./core/metrics.js";
 
-const tracer = trace.getTracer(INSTRUMENTATION_NAME);
-
 /**
- * Record a guard validation result as span attributes and metrics.
+ * Record a guard validation result as attributes on the active span.
  *
- * Attaches guard attributes to a child span and increments counters.
- * If the guard failed, also increments the `would_block` counter —
- * useful for measuring how often shadow guardrails would have blocked.
+ * Attaches guard attributes directly to the current span (no child span created).
+ * Increments guard evaluation counter, and would_block counter if failed.
  */
 export function recordGuardResult(result: GuardResult) {
-  const span = tracer.startSpan(`guard.evaluate.${result.ruleName}`);
+  const activeSpan = trace.getActiveSpan();
 
-  span.setAttributes({
-    [GEN_AI_ATTRS.GUARD_MODE]: result.mode,
-    [GEN_AI_ATTRS.GUARD_PASSED]: result.passed,
-    [GEN_AI_ATTRS.GUARD_RULE_NAME]: result.ruleName,
-    ...(!result.passed &&
-      result.failureReason !== undefined && {
-        [GEN_AI_ATTRS.GUARD_FAILURE_REASON]: result.failureReason,
-      }),
-  });
-
-  span.end();
+  if (activeSpan) {
+    activeSpan.setAttributes({
+      [GEN_AI_ATTRS.GUARD_MODE]: result.mode,
+      [GEN_AI_ATTRS.GUARD_PASSED]: result.passed,
+      [GEN_AI_ATTRS.GUARD_RULE_NAME]: result.ruleName,
+      ...(!result.passed &&
+        result.failureReason !== undefined && {
+          [GEN_AI_ATTRS.GUARD_FAILURE_REASON]: result.failureReason,
+        }),
+    });
+  }
 
   recordGuardEvaluation(result.ruleName);
 

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -188,10 +188,16 @@ function createStreamingHandler(
       ),
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const proxy = Object.create(response as any);
-    proxy[Symbol.asyncIterator] = () => wrapped[Symbol.asyncIterator]();
-    return proxy;
+    // Proxy preserves the original object shape (getters, private fields, methods)
+    // while intercepting only the async iterator for instrumentation
+    return new Proxy(response as object, {
+      get(target, prop, receiver) {
+        if (prop === Symbol.asyncIterator) {
+          return () => wrapped[Symbol.asyncIterator]();
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
   };
 }
 


### PR DESCRIPTION
## Summary
Two quality fixes from BigTech-style code review.

### 1. Stream proxy: Object.create → Proxy
**Before:** `Object.create(response)` — shallow prototype chain, breaks getters/private fields
**After:** `new Proxy(response, { get })` — proper delegation via `Reflect.get`, only intercepts `Symbol.asyncIterator`

### 2. Guard: child spans → active span attributes
**Before:** `tracer.startSpan('guard.evaluate.pii_filter')` — creates child span per rule
**After:** `trace.getActiveSpan().setAttributes(...)` — zero extra spans

| Guard rules per request | Before (spans) | After (spans) |
|---|---|---|
| 1 | 2 (LLM + guard) | 1 (LLM only) |
| 5 | 6 | 1 |
| 10 | 11 | 1 |

## Test plan
- [x] 117/117 instrumentation tests passing (guard tests updated)
- [x] TypeScript strict mode — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)