### PR TITLE
feat: default PII redaction patterns + audit masking (#129)

### DIFF
--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -247,6 +247,123 @@ describe("salted hashing (#98)", () => {
   });
 });
 
+describe("privacy — redactDefaults (#129)", () => {
+  beforeEach(() => {
+    mockConfig = {};
+    mockSpan.setAttributes.mockClear();
+  });
+
+  it("redacts email with redactDefaults: true", async () => {
+    mockConfig = { redactDefaults: true };
+
+    await traceLLMCall(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "Contact john@example.com for help",
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 10,
+        outputTokens: 2,
+        cost: 0,
+      }),
+    );
+
+    const call = mockSpan.setAttributes.mock.calls.find(
+      (c: unknown[]) =>
+        (c[0] as Record<string, unknown>)["gen_ai.toad_eye.prompt"] !==
+        undefined,
+    );
+    const prompt = (call![0] as Record<string, string>)[
+      "gen_ai.toad_eye.prompt"
+    ];
+    expect(prompt).toBe("Contact [REDACTED] for help");
+    expect(prompt).not.toContain("john@example.com");
+  });
+
+  it("redacts SSN with redactDefaults: true", async () => {
+    mockConfig = { redactDefaults: true };
+
+    await traceLLMCall(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "SSN is 123-45-6789",
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 5,
+        outputTokens: 1,
+        cost: 0,
+      }),
+    );
+
+    const call = mockSpan.setAttributes.mock.calls.find(
+      (c: unknown[]) =>
+        (c[0] as Record<string, unknown>)["gen_ai.toad_eye.prompt"] !==
+        undefined,
+    );
+    const prompt = (call![0] as Record<string, string>)[
+      "gen_ai.toad_eye.prompt"
+    ];
+    expect(prompt).toContain("[REDACTED]");
+    expect(prompt).not.toContain("123-45-6789");
+  });
+
+  it("does not redact when redactDefaults is not set", async () => {
+    mockConfig = {};
+
+    await traceLLMCall(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "Email: test@example.com",
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 5,
+        outputTokens: 1,
+        cost: 0,
+      }),
+    );
+
+    const call = mockSpan.setAttributes.mock.calls.find(
+      (c: unknown[]) =>
+        (c[0] as Record<string, unknown>)["gen_ai.toad_eye.prompt"] !==
+        undefined,
+    );
+    const prompt = (call![0] as Record<string, string>)[
+      "gen_ai.toad_eye.prompt"
+    ];
+    expect(prompt).toContain("test@example.com");
+  });
+
+  it("audit mode logs masked content", async () => {
+    mockConfig = { redactDefaults: true, auditMasking: true };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await traceLLMCall(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "User email: admin@corp.com",
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 5,
+        outputTokens: 1,
+        cost: 0,
+      }),
+    );
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[toad-eye audit]"),
+    );
+    logSpy.mockRestore();
+  });
+});
+
 describe("FinOps attributes", () => {
   beforeEach(() => {
     mockConfig = {};

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -55,16 +55,37 @@ function sha256(text: string): string {
     .digest("hex");
 }
 
+// Built-in PII patterns — enabled via redactDefaults: true
+const DEFAULT_REDACT_PATTERNS: readonly RegExp[] = [
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g, // email
+  /\b\d{3}-\d{2}-\d{4}\b/g, // SSN (US)
+  /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g, // credit card
+  /\b\+?\d{1,3}[\s.-]?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\b/g, // phone
+];
+
 function processContent(text: string): string | undefined {
   const config = getConfig();
   if (config?.recordContent === false) return undefined;
 
   let processed = text;
 
+  // Apply default PII patterns if enabled
+  if (config?.redactDefaults) {
+    for (const pattern of DEFAULT_REDACT_PATTERNS) {
+      processed = processed.replace(pattern, "[REDACTED]");
+    }
+  }
+
+  // Apply custom patterns
   if (config?.redactPatterns?.length) {
     for (const pattern of config.redactPatterns) {
       processed = processed.replace(pattern, "[REDACTED]");
     }
+  }
+
+  // Audit mode — log what changed (for debugging config)
+  if (config?.auditMasking && processed !== text) {
+    console.log(`[toad-eye audit] Content masked: "${text}" → "${processed}"`);
   }
 
   if (config?.hashContent) {

--- a/packages/instrumentation/src/types/config.ts
+++ b/packages/instrumentation/src/types/config.ts
@@ -31,6 +31,10 @@ export interface ToadEyeConfig {
   readonly salt?: string | undefined;
   /** Regex patterns to redact from prompt/completion text before recording. */
   readonly redactPatterns?: readonly RegExp[] | undefined;
+  /** Enable built-in redaction patterns for common PII: email, SSN, credit card, phone. */
+  readonly redactDefaults?: boolean | undefined;
+  /** Log what was masked to console (for debugging redaction config). No data is sent externally. */
+  readonly auditMasking?: boolean | undefined;
 
   // Auto-instrumentation
   readonly instrument?: readonly LLMProvider[] | undefined;


### PR DESCRIPTION
## Summary
Built-in PII redaction for email, SSN, credit card, phone. One flag instead of manual regex.

## Usage
```typescript
initObservability({
  serviceName: 'my-app',
  redactDefaults: true,    // email, SSN, CC, phone → [REDACTED]
  auditMasking: true,      // logs what was masked (debug only)
});
```

## What gets redacted
| Pattern | Example | After |
|---------|---------|-------|
| Email | `john@example.com` | `[REDACTED]` |
| SSN | `123-45-6789` | `[REDACTED]` |
| Credit card | `4111 1111 1111 1111` | `[REDACTED]` |
| Phone | `+1-555-123-4567` | `[REDACTED]` |

Custom `redactPatterns` still work alongside defaults.

## Test plan
- [x] 129/129 tests passing (4 new)
- [x] TypeScript strict mode — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)