### PR TITLE
feat: multi-agent support — handoffs, loop detection, maxSteps (#133)

### DIFF
--- a/packages/instrumentation/src/__tests__/agent.test.ts
+++ b/packages/instrumentation/src/__tests__/agent.test.ts
@@ -4,6 +4,7 @@ const mockSpan = {
   setAttribute: vi.fn(),
   setAttributes: vi.fn(),
   setStatus: vi.fn(),
+  addEvent: vi.fn(),
   end: vi.fn(),
 };
 
@@ -169,5 +170,108 @@ describe("traceAgentQuery", () => {
       "gen_ai.agent.step.content",
       expect.anything(),
     );
+  });
+});
+
+describe("handoff steps (#133)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = {};
+  });
+
+  it("records handoff attributes on step span", () => {
+    traceAgentStep({
+      type: "handoff",
+      stepNumber: 3,
+      toAgent: "specialist",
+      handoffReason: "needs domain expertise",
+    });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.agent.step.type": "handoff",
+        "gen_ai.agent.handoff.to": "specialist",
+        "gen_ai.agent.handoff.reason": "needs domain expertise",
+      }),
+    );
+  });
+});
+
+describe("loop detection (#133)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = {};
+  });
+
+  it("counts observe→think transitions as loops", async () => {
+    await traceAgentQuery("test", async (step) => {
+      step({ type: "think", stepNumber: 1 });
+      step({ type: "act", stepNumber: 2, toolName: "search" });
+      step({ type: "observe", stepNumber: 3 });
+      // Loop 1: observe → think
+      step({ type: "think", stepNumber: 4 });
+      step({ type: "act", stepNumber: 5, toolName: "search" });
+      step({ type: "observe", stepNumber: 6 });
+      // Loop 2: observe → think
+      step({ type: "think", stepNumber: 7 });
+      step({ type: "answer", stepNumber: 8 });
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.agent.loop_count",
+      2,
+    );
+  });
+
+  it("records 0 loops for linear flow", async () => {
+    await traceAgentQuery("test", async (step) => {
+      step({ type: "think", stepNumber: 1 });
+      step({ type: "act", stepNumber: 2, toolName: "calc" });
+      step({ type: "observe", stepNumber: 3 });
+      step({ type: "answer", stepNumber: 4 });
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.agent.loop_count",
+      0,
+    );
+  });
+
+  it("emits warning when maxSteps exceeded", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await traceAgentQuery(
+      "test",
+      async (step) => {
+        for (let i = 1; i <= 5; i++) {
+          step({ type: "think", stepNumber: i });
+        }
+      },
+      { maxSteps: 3 },
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("exceeded maxSteps"),
+    );
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(
+      "agent.max_steps_exceeded",
+      expect.objectContaining({
+        "agent.max_steps": 3,
+      }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn when within maxSteps", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await traceAgentQuery("test", async (step) => {
+      step({ type: "think", stepNumber: 1 });
+      step({ type: "answer", stepNumber: 2 });
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(mockSpan.addEvent).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -1,19 +1,16 @@
 import { trace, SpanStatusCode } from "@opentelemetry/api";
-import type { AgentStepInput } from "./types/index.js";
+import type { AgentStepInput, AgentQueryOptions } from "./types/index.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
 import { recordAgentSteps, recordAgentToolUsage } from "./core/metrics.js";
 import { getConfig } from "./core/tracer.js";
 
 const tracer = trace.getTracer(INSTRUMENTATION_NAME);
 
+const DEFAULT_MAX_STEPS = 25;
+
 /**
- * Record a single agent step as a child span (ReAct pattern: think → act → observe → answer).
- *
- * Creates a short-lived span under the current active context. Call this inside
- * {@link traceAgentQuery} (preferred) or any other active span (e.g. traceLLMCall).
- *
- * - Respects `recordContent` config — content is omitted when recording is disabled.
- * - For `act` steps with a `toolName`, automatically increments the `agent.tool_usage` metric.
+ * Record a single agent step as a child span (ReAct pattern).
+ * Supports: think, act, observe, answer, handoff.
  */
 function traceAgentStep(input: AgentStepInput) {
   const span = tracer.startSpan(`agent.step.${input.type}`);
@@ -31,6 +28,13 @@ function traceAgentStep(input: AgentStepInput) {
       input.content !== undefined && {
         [GEN_AI_ATTRS.AGENT_STEP_CONTENT]: input.content,
       }),
+    // Handoff attributes
+    ...(input.toAgent !== undefined && {
+      [GEN_AI_ATTRS.AGENT_HANDOFF_TO]: input.toAgent,
+    }),
+    ...(input.handoffReason !== undefined && {
+      [GEN_AI_ATTRS.AGENT_HANDOFF_REASON]: input.handoffReason,
+    }),
   });
 
   if (input.type === "act" && input.toolName !== undefined) {
@@ -42,57 +46,79 @@ function traceAgentStep(input: AgentStepInput) {
 }
 
 /**
- * Wrap an entire agent query in a parent span, producing structured ReAct traces.
+ * Wrap an entire agent query in a parent span with ReAct tracing.
  *
- * The callback receives a `step` function to record individual steps.
- * When the callback completes, the wrapper automatically records the
- * `agent.steps_per_query` histogram metric with the total step count.
+ * Supports multi-agent via nesting — child traceAgentQuery calls
+ * automatically become child spans in Jaeger.
  *
- * Span hierarchy in Jaeger:
- * ```
- * [parent] agent.query "Is anything dangerous near Earth?"
- *   ├── agent.step.think   "I need to check asteroids"
- *   ├── agent.step.act     tool=near-earth-asteroids
- *   ├── agent.step.observe "7 asteroids found"
- *   └── agent.step.answer  "7 asteroids passing safely..."
- * ```
+ * Loop detection: counts observe→think transitions. Records loop count
+ * as span attribute. Emits warning when maxSteps exceeded.
  *
  * @example
  * ```ts
- * const result = await traceAgentQuery("Is anything dangerous near Earth?", async (step) => {
- *   step({ type: "think", stepNumber: 1, content: "I need to check asteroids" });
- *   const data = await callTool("near-earth-asteroids");
- *   step({ type: "act", stepNumber: 2, toolName: "near-earth-asteroids" });
- *   step({ type: "observe", stepNumber: 3, content: `${data.length} asteroids found` });
- *   step({ type: "answer", stepNumber: 4, content: "7 asteroids passing safely..." });
- *   return { answer: "7 asteroids passing safely..." };
+ * // Multi-agent: orchestrator delegates to specialist
+ * await traceAgentQuery('orchestrator', async (step) => {
+ *   step({ type: 'think', stepNumber: 1, content: 'Need domain expert' });
+ *   step({ type: 'handoff', stepNumber: 2, toAgent: 'specialist', handoffReason: 'domain expertise' });
+ *
+ *   const result = await traceAgentQuery('specialist', async (step) => {
+ *     step({ type: 'act', stepNumber: 1, toolName: 'analyze' });
+ *     step({ type: 'answer', stepNumber: 2, content: 'analysis complete' });
+ *     return { answer: 'done' };
+ *   });
  * });
  * ```
  */
 export async function traceAgentQuery<T>(
   query: string,
   fn: (step: (input: AgentStepInput) => void) => Promise<T>,
+  options?: AgentQueryOptions,
 ): Promise<T> {
   return tracer.startActiveSpan(`agent.query`, async (span) => {
     const config = getConfig();
     const recordContent = config?.recordContent !== false;
+    const maxSteps = options?.maxSteps ?? DEFAULT_MAX_STEPS;
 
     if (recordContent) {
       span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, query);
     }
 
     let stepCount = 0;
+    let loopCount = 0;
+    let lastStepType: string | undefined;
+    let maxStepsWarned = false;
 
     try {
       const result = await fn((input) => {
         stepCount++;
+
+        // Loop detection: observe → think = one loop iteration
+        if (input.type === "think" && lastStepType === "observe") {
+          loopCount++;
+        }
+        lastStepType = input.type;
+
+        // Max steps guard
+        if (stepCount > maxSteps && !maxStepsWarned) {
+          maxStepsWarned = true;
+          console.warn(
+            `toad-eye: agent exceeded maxSteps (${maxSteps}). Current: ${stepCount}`,
+          );
+          span.addEvent("agent.max_steps_exceeded", {
+            "agent.max_steps": maxSteps,
+            "agent.current_steps": stepCount,
+          });
+        }
+
         traceAgentStep(input);
       });
 
+      span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
       span.setStatus({ code: SpanStatusCode.OK });
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
       span.setStatus({ code: SpanStatusCode.ERROR, message });
       throw error;
     } finally {

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -57,6 +57,7 @@ export type {
   MetricName,
   AgentStepType,
   AgentStepInput,
+  AgentQueryOptions,
   GuardMode,
   GuardResult,
   InstrumentTarget,

--- a/packages/instrumentation/src/types/attributes.ts
+++ b/packages/instrumentation/src/types/attributes.ts
@@ -22,6 +22,9 @@ export const GEN_AI_ATTRS = {
   AGENT_STEP_NUMBER: "gen_ai.agent.step.number",
   AGENT_TOOL_NAME: "gen_ai.agent.tool.name",
   AGENT_STEP_CONTENT: "gen_ai.agent.step.content",
+  AGENT_HANDOFF_TO: "gen_ai.agent.handoff.to",
+  AGENT_HANDOFF_REASON: "gen_ai.agent.handoff.reason",
+  AGENT_LOOP_COUNT: "gen_ai.agent.loop_count",
 
   // Guard (shadow mode) attributes
   GUARD_MODE: "gen_ai.toad_eye.guard.mode",

--- a/packages/instrumentation/src/types/index.ts
+++ b/packages/instrumentation/src/types/index.ts
@@ -21,6 +21,7 @@ export type {
   LLMSpanAttributes,
   AgentStepType,
   AgentStepInput,
+  AgentQueryOptions,
   GuardMode,
   GuardResult,
 } from "./spans.js";

--- a/packages/instrumentation/src/types/spans.ts
+++ b/packages/instrumentation/src/types/spans.ts
@@ -3,8 +3,8 @@ import type { LLMProvider } from "./providers.js";
 /** Span status values used in trace attributes. */
 export type SpanStatus = "success" | "error";
 
-/** ReAct agent step types: think → act → observe → answer */
-export type AgentStepType = "think" | "act" | "observe" | "answer";
+/** ReAct agent step types: think → act → observe → answer → handoff */
+export type AgentStepType = "think" | "act" | "observe" | "answer" | "handoff";
 
 /** Input for traceAgentStep — describes a single agent step */
 export interface AgentStepInput {
@@ -12,6 +12,16 @@ export interface AgentStepInput {
   readonly stepNumber: number;
   readonly content?: string | undefined;
   readonly toolName?: string | undefined;
+  /** Target agent name for handoff steps */
+  readonly toAgent?: string | undefined;
+  /** Reason for handoff */
+  readonly handoffReason?: string | undefined;
+}
+
+/** Options for traceAgentQuery */
+export interface AgentQueryOptions {
+  /** Max steps before recording a warning. Default: 25 */
+  readonly maxSteps?: number | undefined;
 }
 
 /** Guard execution mode */


### PR DESCRIPTION
## Summary
Multi-agent observability for complex agent systems — delegation tracking, loop detection, runaway prevention.

## New capabilities

### Handoffs
```typescript
step({ type: 'handoff', stepNumber: 3, toAgent: 'specialist', handoffReason: 'domain expertise' });
```

### Nested agents (auto parent-child spans)
```typescript
await traceAgentQuery('orchestrator', async (step) => {
  step({ type: 'handoff', stepNumber: 2, toAgent: 'specialist' });
  await traceAgentQuery('specialist', async (step) => {
    // child span in Jaeger
  });
});
```

### Loop detection
Counts observe→think transitions. Records `gen_ai.agent.loop_count` on span.

### Max steps guard
```typescript
await traceAgentQuery('agent', fn, { maxSteps: 30 });
// Warns + span event when exceeded
```

## Test plan
- [x] 143/143 tests passing (5 new)
- [x] TypeScript strict mode — clean

🐸 Generated with [Claude Code](https://claude.com/claude-code)