### PR TITLE
fix(privacy): audit masking no longer leaks PII to logs + regex g flag safety

### DIFF
--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -339,7 +339,7 @@ describe("privacy — redactDefaults (#129)", () => {
     expect(prompt).toContain("test@example.com");
   });
 
-  it("audit mode logs masked content", async () => {
+  it("audit mode logs a summary without exposing original PII", async () => {
     mockConfig = { redactDefaults: true, auditMasking: true };
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -360,7 +360,35 @@ describe("privacy — redactDefaults (#129)", () => {
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining("[toad-eye audit]"),
     );
+    // Must NOT log the original PII
+    const loggedMessage = logSpy.mock.calls[0]?.[0] as string;
+    expect(loggedMessage).not.toContain("admin@corp.com");
+    expect(loggedMessage).toContain("pattern(s) applied");
     logSpy.mockRestore();
+  });
+
+  it("redacted prompt is NOT present in span attributes (negative test)", async () => {
+    mockConfig = { redactDefaults: true };
+
+    await traceLLMCall(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        prompt: "SSN: 123-45-6789 and card 4111-1111-1111-1111",
+      },
+      async () => ({
+        completion: "ok",
+        inputTokens: 10,
+        outputTokens: 1,
+        cost: 0,
+      }),
+    );
+
+    const allAttrs = mockSpan.setAttributes.mock.calls.flatMap(
+      (call: unknown[]) => Object.values(call[0] as Record<string, unknown>),
+    );
+    expect(allAttrs).not.toContain("123-45-6789");
+    expect(allAttrs).not.toContain("4111-1111-1111-1111");
   });
 });
 

--- a/packages/instrumentation/src/alerts/index.ts
+++ b/packages/instrumentation/src/alerts/index.ts
@@ -12,9 +12,31 @@ import yaml from "yaml";
 import { AlertManager } from "./manager.js";
 import type { AlertsConfig } from "./types.js";
 
+/** Resolve ${ENV_VAR} references in string values throughout the config. */
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, name: string) => {
+    return process.env[name] ?? `\${${name}}`;
+  });
+}
+
+function interpolateConfig(obj: unknown): unknown {
+  if (typeof obj === "string") return resolveEnvVars(obj);
+  if (Array.isArray(obj)) return obj.map(interpolateConfig);
+  if (obj !== null && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj as Record<string, unknown>).map(([k, v]) => [
+        k,
+        interpolateConfig(v),
+      ]),
+    );
+  }
+  return obj;
+}
+
 export function startAlertsFromFile(configPath: string): AlertManager {
   const raw = readFileSync(configPath, "utf-8");
-  const config = yaml.parse(raw) as AlertsConfig;
+  const parsed = yaml.parse(raw) as AlertsConfig;
+  const config = interpolateConfig(parsed) as AlertsConfig;
   const manager = new AlertManager(config);
   manager.start();
   return manager;

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -56,36 +56,54 @@ function sha256(text: string): string {
 }
 
 // Built-in PII patterns — enabled via redactDefaults: true
+// Note: no `g` flag here — a fresh RegExp is created per call to avoid lastIndex state issues
 const DEFAULT_REDACT_PATTERNS: readonly RegExp[] = [
-  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g, // email
-  /\b\d{3}-\d{2}-\d{4}\b/g, // SSN (US)
-  /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g, // credit card
-  /\b\+?\d{1,3}[\s.-]?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\b/g, // phone
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/, // email
+  /\b\d{3}-\d{2}-\d{4}\b/, // SSN (US)
+  /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/, // credit card
+  /\b\+?\d{1,3}[\s.-]?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\b/, // phone
 ];
+
+function applyRedaction(text: string, pattern: RegExp): [string, number] {
+  let count = 0;
+  const regex = new RegExp(pattern.source, "g");
+  const result = text.replace(regex, () => {
+    count++;
+    return "[REDACTED]";
+  });
+  return [result, count];
+}
 
 function processContent(text: string): string | undefined {
   const config = getConfig();
   if (config?.recordContent === false) return undefined;
 
   let processed = text;
+  let totalRedacted = 0;
 
   // Apply default PII patterns if enabled
   if (config?.redactDefaults) {
     for (const pattern of DEFAULT_REDACT_PATTERNS) {
-      processed = processed.replace(pattern, "[REDACTED]");
+      const [result, count] = applyRedaction(processed, pattern);
+      processed = result;
+      totalRedacted += count;
     }
   }
 
   // Apply custom patterns
   if (config?.redactPatterns?.length) {
     for (const pattern of config.redactPatterns) {
-      processed = processed.replace(pattern, "[REDACTED]");
+      const [result, count] = applyRedaction(processed, pattern);
+      processed = result;
+      totalRedacted += count;
     }
   }
 
-  // Audit mode — log what changed (for debugging config)
-  if (config?.auditMasking && processed !== text) {
-    console.log(`[toad-eye audit] Content masked: "${text}" → "${processed}"`);
+  // Audit mode — log a summary only, never the original content (would re-expose PII)
+  if (config?.auditMasking && totalRedacted > 0) {
+    console.log(
+      `[toad-eye audit] Content masked: ${totalRedacted} pattern(s) applied, ${text.length} chars → ${processed.length} chars`,
+    );
   }
 
   if (config?.hashContent) {


### PR DESCRIPTION
## Summary

- `auditMasking` now logs only a summary (`2 pattern(s) applied, 45 chars → 32 chars`), never the original content — previously logged plaintext PII to console which forwarded to log aggregators (CloudWatch, Datadog), completely defeating redaction
- Extracted `applyRedaction()` helper that creates a fresh `RegExp` per call, eliminating shared `g`-flag `lastIndex` state on `DEFAULT_REDACT_PATTERNS`
- `startAlertsFromFile` now resolves `${ENV_VAR}` references in YAML config values so Telegram tokens and SMTP passwords don't need to be hardcoded in plain text
- Added negative test: verifies original PII strings are absent from all span attributes after redaction
- Updated `auditMasking` test: asserts summary format and that original PII is not present in the log message

## Test plan

- [x] All 522 tests pass (`npx vitest run`)
- [x] `auditMasking` test verifies log contains `"pattern(s) applied"` and does NOT contain original email
- [x] Negative test verifies SSN/CC not present in any span attributes after redaction
- [x] `${ENV_VAR}` in alerts YAML resolves from `process.env`

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)