### PR TITLE
fix(cli): execFileSync for injection safety + exact service matching + tests

### DIFF
--- a/packages/instrumentation/src/__tests__/cli.test.ts
+++ b/packages/instrumentation/src/__tests__/cli.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { findContainerByService } from "../cli.js";
+
+const MOCK_CONTAINERS = [
+  { Service: "grafana", State: "running" },
+  { Service: "jaeger", State: "running" },
+  { Service: "prometheus", State: "exited" },
+  { Service: "collector", State: "running" },
+];
+
+describe("findContainerByService", () => {
+  it("matches by exact service name", () => {
+    expect(findContainerByService(MOCK_CONTAINERS, "grafana")?.State).toBe(
+      "running",
+    );
+  });
+
+  it("matches collector service", () => {
+    expect(findContainerByService(MOCK_CONTAINERS, "collector")?.State).toBe(
+      "running",
+    );
+  });
+
+  it("matches stopped service correctly", () => {
+    expect(findContainerByService(MOCK_CONTAINERS, "prometheus")?.State).toBe(
+      "exited",
+    );
+  });
+
+  it("returns undefined for unknown service key", () => {
+    expect(findContainerByService(MOCK_CONTAINERS, "unknown")).toBeUndefined();
+  });
+
+  it("does not match partial names (old bug: 'a' would match everything)", () => {
+    expect(findContainerByService(MOCK_CONTAINERS, "a")).toBeUndefined();
+  });
+
+  it("does not match superstrings (old bug: display name includes container name)", () => {
+    // Old logic: "jaeger ui".includes("jaeger") — fragile
+    // New logic: exact match only
+    expect(
+      findContainerByService(MOCK_CONTAINERS, "jaeger ui"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty containers list", () => {
+    expect(findContainerByService([], "grafana")).toBeUndefined();
+  });
+});

--- a/packages/instrumentation/src/cli.ts
+++ b/packages/instrumentation/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync, type ChildProcess, spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,10 +21,19 @@ const DEMO_TOKEN_INPUT_RANGE = [50, 500] as const;
 const DEMO_TOKEN_OUTPUT_RANGE = [20, 300] as const;
 
 const SERVICES = [
-  { name: "Grafana", url: "http://localhost:3100", login: "admin / admin" },
-  { name: "Jaeger UI", url: "http://localhost:16686" },
-  { name: "Prometheus", url: "http://localhost:9090" },
-  { name: "OTel Collector", url: "http://localhost:4318" },
+  {
+    name: "Grafana",
+    service: "grafana",
+    url: "http://localhost:3100",
+    login: "admin / admin",
+  },
+  { name: "Jaeger UI", service: "jaeger", url: "http://localhost:16686" },
+  { name: "Prometheus", service: "prometheus", url: "http://localhost:9090" },
+  {
+    name: "OTel Collector",
+    service: "collector",
+    url: "http://localhost:4318",
+  },
 ] as const;
 
 function getTemplatesDir(): string {
@@ -76,7 +85,9 @@ function up() {
   const composeFile = requireInfra();
 
   console.log("\u{1f438} Starting observability stack...");
-  execSync(`docker compose -f ${composeFile} up -d`, { stdio: "inherit" });
+  execFileSync("docker", ["compose", "-f", composeFile, "up", "-d"], {
+    stdio: "inherit",
+  });
   console.log();
   status();
 }
@@ -85,19 +96,28 @@ function down() {
   const composeFile = requireInfra("Nothing to stop.");
 
   console.log("\u{1f44b} Stopping observability stack...");
-  execSync(`docker compose -f ${composeFile} down`, { stdio: "inherit" });
+  execFileSync("docker", ["compose", "-f", composeFile, "down"], {
+    stdio: "inherit",
+  });
   console.log("\u2705 Stack stopped.");
+}
+
+/** Find the docker container matching a service by exact service name. Exported for testing. */
+export function findContainerByService(
+  containers: ReadonlyArray<{ Service: string; State: string }>,
+  serviceKey: string,
+): { Service: string; State: string } | undefined {
+  return containers.find((c) => c.Service === serviceKey);
 }
 
 function status() {
   const composeFile = requireInfra();
 
   try {
-    const output = execSync(
-      `docker compose -f ${composeFile} ps --format json`,
-      {
-        encoding: "utf-8",
-      },
+    const output = execFileSync(
+      "docker",
+      ["compose", "-f", composeFile, "ps", "--format", "json"],
+      { encoding: "utf-8" },
     );
 
     const lines = output.trim().split("\n").filter(Boolean);
@@ -109,9 +129,7 @@ function status() {
     console.log();
 
     for (const svc of SERVICES) {
-      const container = containers.find((c) =>
-        svc.name.toLowerCase().includes(c.Service.toLowerCase()),
-      );
+      const container = findContainerByService(containers, svc.service);
       const state = container?.State === "running" ? "\u{1f7e2}" : "\u{1f534}";
       const loginInfo = "login" in svc ? ` (${svc.login})` : "";
       console.log(`  ${state} ${svc.name.padEnd(16)} ${svc.url}${loginInfo}`);
@@ -266,35 +284,45 @@ Commands:
 `);
 }
 
-const command = process.argv[2];
+function runCli() {
+  const command = process.argv[2];
 
-switch (command) {
-  case "init":
-    init();
-    break;
-  case "up":
-    up();
-    break;
-  case "down":
-    down();
-    break;
-  case "status":
-    status();
-    break;
-  case "demo":
-    demo();
-    break;
-  case "export-trace":
-    exportTraceCommand();
-    break;
-  case "help":
-  case "--help":
-  case "-h":
-  case undefined:
-    help();
-    break;
-  default:
-    console.error(`Unknown command: ${command}`);
-    help();
-    process.exit(1);
+  switch (command) {
+    case "init":
+      init();
+      break;
+    case "up":
+      up();
+      break;
+    case "down":
+      down();
+      break;
+    case "status":
+      status();
+      break;
+    case "demo":
+      demo();
+      break;
+    case "export-trace":
+      exportTraceCommand();
+      break;
+    case "help":
+    case "--help":
+    case "-h":
+    case undefined:
+      help();
+      break;
+    default:
+      console.error(`Unknown command: ${command}`);
+      help();
+      process.exit(1);
+  }
+}
+
+// Only auto-execute when run as CLI entry point, not when imported (e.g., in tests)
+if (
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  runCli();
 }


### PR DESCRIPTION
## Summary

- Replace all `execSync` string-template calls with `execFileSync` + arg arrays in `up()`, `down()`, `status()` — eliminates command injection when project paths contain spaces or shell metacharacters (e.g. `/Users/John Doe/my project/`)
- Add explicit `service` key to `SERVICES` entries mapping to actual docker compose service names (`grafana`, `jaeger`, `prometheus`, `collector`); use exact equality in `findContainerByService()` instead of the inverted `String.includes()` that could match any service when container name is a short string
- Extract `findContainerByService()` as an exported pure function
- Wrap CLI `switch()` in `runCli()` guarded by `import.meta.url` check so the module can be imported in tests without triggering `process.exit()`
- Add `__tests__/cli.test.ts` with 7 tests covering exact match, stopped service, unknown key, and regression cases for the old partial-match bug

## Test plan

- [ ] All 529 tests pass (`npx vitest run`)
- [ ] `findContainerByService` tests cover exact match + partial name regression
- [ ] `up`/`down`/`status` use `execFileSync` — verified by reading cli.ts

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)