### PR TITLE
fix(singleton): full state reset on shutdown + lifecycle warnings

### DIFF
--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -54,6 +54,27 @@ describe("traceLLMCall", () => {
     mockSpan.setStatus.mockClear();
   });
 
+  it("warns via diag when called without initObservability", async () => {
+    const { diag } = await import("@opentelemetry/api");
+    mockConfig = undefined as unknown as Record<string, unknown>;
+
+    await traceLLMCall(
+      { provider: "openai", model: "gpt-4o", prompt: "hello" },
+      async () => ({
+        completion: "world",
+        inputTokens: 1,
+        outputTokens: 1,
+        cost: 0,
+      }),
+    );
+
+    expect(diag.warn).toHaveBeenCalledWith(
+      expect.stringContaining("initObservability"),
+    );
+
+    mockConfig = {};
+  });
+
   it("returns output from wrapped function", async () => {
     const output = await traceLLMCall(
       { provider: "openai", model: "gpt-4o", prompt: "hello" },

--- a/packages/instrumentation/src/__tests__/tracer.test.ts
+++ b/packages/instrumentation/src/__tests__/tracer.test.ts
@@ -27,7 +27,16 @@ vi.mock("@opentelemetry/api", () => ({
   diag: { warn: vi.fn(), debug: vi.fn() },
   trace: { getTracer: () => ({}) },
 }));
-vi.mock("../core/metrics.js", () => ({ initMetrics: vi.fn() }));
+vi.mock("../core/metrics.js", () => ({
+  initMetrics: vi.fn(),
+  resetMetrics: vi.fn(),
+}));
+vi.mock("../core/pricing.js", () => ({
+  resetCustomPricing: vi.fn(),
+  calculateCost: vi.fn(),
+  setCustomPricing: vi.fn(),
+  getModelPricing: vi.fn(),
+}));
 vi.mock("../instrumentations/registry.js", () => ({
   enableAll: vi.fn(),
   disableAll: vi.fn(),
@@ -138,5 +147,32 @@ describe("initObservability — cloud mode", () => {
     );
 
     await shutdown();
+  });
+});
+
+describe("singleton lifecycle", () => {
+  it("warns when initObservability is called twice", async () => {
+    const { diag } = await import("@opentelemetry/api");
+    await shutdown();
+
+    initObservability({ serviceName: "first" });
+    initObservability({ serviceName: "second" });
+
+    expect(diag.warn).toHaveBeenCalledWith(
+      expect.stringContaining("already called"),
+    );
+
+    await shutdown();
+  });
+
+  it("calls resetMetrics and resetCustomPricing on shutdown", async () => {
+    const { resetMetrics } = await import("../core/metrics.js");
+    const { resetCustomPricing } = await import("../core/pricing.js");
+
+    initObservability({ serviceName: "reset-test" });
+    await shutdown();
+
+    expect(resetMetrics).toHaveBeenCalled();
+    expect(resetCustomPricing).toHaveBeenCalled();
   });
 });

--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -110,6 +110,11 @@ export function initMetrics() {
   initialized = true;
 }
 
+/** Reset metrics state so the next initMetrics() creates fresh instruments. Called from shutdown(). */
+export function resetMetrics() {
+  initialized = false;
+}
+
 /** Build metric labels: provider + model + optional FinOps attributes. */
 function baseLabels(
   provider: string,

--- a/packages/instrumentation/src/core/pricing.ts
+++ b/packages/instrumentation/src/core/pricing.ts
@@ -42,6 +42,11 @@ export function setCustomPricing(pricing: Record<string, ModelPricing>) {
   customPricing = { ...pricing };
 }
 
+/** Reset custom pricing to empty. Called from shutdown() to avoid stale state across re-inits. */
+export function resetCustomPricing() {
+  customPricing = {};
+}
+
 /**
  * Get pricing for a model. Custom pricing takes precedence.
  * Returns undefined if model is not in any pricing table.

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -38,10 +38,18 @@ export interface LLMCallOutput {
 const tracer = trace.getTracer(INSTRUMENTATION_NAME);
 
 let saltWarningEmitted = false;
+// Track the last config ref so saltWarningEmitted resets across re-inits without circular imports
+let lastConfigRef: object | null = null;
 
 function sha256(text: string): string {
   const config = getConfig();
   const salt = config?.salt ?? "";
+
+  // Auto-reset saltWarningEmitted when SDK is re-initialized (config ref changes)
+  if (config !== lastConfigRef) {
+    lastConfigRef = config;
+    saltWarningEmitted = false;
+  }
 
   if (config?.hashContent && !config.salt && !saltWarningEmitted) {
     diag.warn(
@@ -190,6 +198,12 @@ export async function traceLLMCall(
   input: LLMCallInput,
   fn: () => Promise<LLMCallOutput>,
 ): Promise<LLMCallOutput> {
+  if (!getConfig()) {
+    diag.warn(
+      "toad-eye: traceLLMCall called before initObservability() — no telemetry will be recorded.",
+    );
+  }
+
   const budget = getBudgetTracker();
   let effectiveInput = input;
 

--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -8,8 +8,10 @@ import {
   ParentBasedSampler,
 } from "@opentelemetry/sdk-trace-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { diag } from "@opentelemetry/api";
 import type { ToadEyeConfig } from "../types/index.js";
-import { initMetrics } from "./metrics.js";
+import { initMetrics, resetMetrics } from "./metrics.js";
+import { resetCustomPricing } from "./pricing.js";
 import { enableAll, disableAll } from "../instrumentations/registry.js";
 import { BudgetTracker } from "../budget/index.js";
 import { ToadEyeAISpanProcessor } from "../vercel.js";
@@ -65,7 +67,12 @@ function resolveTransport(config: ToadEyeConfig) {
 }
 
 export function initObservability(config: ToadEyeConfig) {
-  if (sdk) return;
+  if (sdk) {
+    diag.warn(
+      "toad-eye: initObservability() already called. Call shutdown() first to reconfigure.",
+    );
+    return;
+  }
 
   validateConfig(config);
   const { endpoint, headers, isCloudMode } = resolveTransport(config);
@@ -150,4 +157,6 @@ export async function shutdown() {
   sdk = null;
   currentConfig = null;
   budgetTracker = null;
+  resetMetrics();
+  resetCustomPricing();
 }


### PR DESCRIPTION
## Summary

- `resetMetrics()` added to `metrics.ts`: sets `initialized=false` so the next `initObservability()` creates fresh meter instruments instead of reusing stale ones from the previous SDK instance
- `resetCustomPricing()` added to `pricing.ts`: clears user-defined pricing that would otherwise persist silently across shutdown/re-init cycles
- Both reset functions called from `shutdown()` for a clean slate
- `diag.warn()` in `initObservability()` when called a second time without `shutdown()` — second config is still dropped but now at least the user is informed
- `diag.warn()` in `traceLLMCall()` when called before `initObservability()` — users no longer silently get no-op OTel spans
- `saltWarningEmitted` now auto-resets when config ref changes (new SDK init) — no circular import needed between `spans.ts` and `tracer.ts`

## Test plan

- [ ] All 532 tests pass (`npx vitest run`)
- [ ] `singleton lifecycle` tests: double-init warns, shutdown calls resets
- [ ] `traceLLMCall without init` test: `diag.warn` is called with `"initObservability"` in message

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)