### PR TITLE
fix: budget race condition via cost reservation + fix hardcoded metric type

### DIFF
--- a/packages/instrumentation/src/__tests__/budget.test.ts
+++ b/packages/instrumentation/src/__tests__/budget.test.ts
@@ -44,7 +44,11 @@ describe("BudgetTracker", () => {
         provider: "openai",
         model: "gpt-4o",
       });
-      expect(result).toEqual({ provider: "openai", model: "gpt-4o-mini" });
+      expect(result).toEqual({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        budget: "daily",
+      });
     });
   });
 
@@ -166,6 +170,69 @@ describe("BudgetTracker", () => {
       });
       expect(error.message).toContain("user user-123");
       expect(error.userId).toBe("user-123");
+    });
+  });
+
+  describe("cost reservation (race condition guard)", () => {
+    it("counts in-flight reservations against daily budget", () => {
+      const tracker = new BudgetTracker({ daily: 1 }, "block");
+      // Reserve $0.80 — simulate an in-flight request
+      tracker.checkBefore("openai", "gpt-4o", undefined, 0.8);
+      // Second request estimates $0.30 — total reserved+actual would be $1.10, over limit
+      expect(() =>
+        tracker.checkBefore("openai", "gpt-4o", undefined, 0.3),
+      ).toThrow(ToadBudgetExceededError);
+    });
+
+    it("releases reservation when recordCost is called", () => {
+      const tracker = new BudgetTracker({ daily: 1 }, "block");
+      tracker.checkBefore("openai", "gpt-4o", undefined, 0.8);
+      // Record actual cost — releases the $0.80 reservation
+      tracker.recordCost(0.5, "gpt-4o", undefined, 0.8);
+      // Now only $0.50 is used; a new request with $0.30 estimate should pass
+      expect(
+        tracker.checkBefore("openai", "gpt-4o", undefined, 0.3),
+      ).toBeNull();
+    });
+
+    it("releases reservation via releaseReservation on error", () => {
+      const tracker = new BudgetTracker({ daily: 1 }, "block");
+      tracker.checkBefore("openai", "gpt-4o", undefined, 0.8);
+      // Simulate LLM call failure — release without recording cost
+      tracker.releaseReservation(0.8);
+      // Budget should be free again
+      expect(
+        tracker.checkBefore("openai", "gpt-4o", undefined, 0.3),
+      ).toBeNull();
+    });
+
+    it("reservation does not affect perUser or perModel checks", () => {
+      const tracker = new BudgetTracker({ perModel: { "gpt-4o": 5 } }, "block");
+      // Large reservation — but perModel is checked separately, not via reservedCost
+      tracker.checkBefore("openai", "gpt-4o", undefined, 100);
+      // perModel check: $0 recorded, still within $5 limit
+      expect(tracker.checkBefore("openai", "gpt-4o", undefined, 0)).toBeNull();
+    });
+
+    it("downgrade result includes budget type that triggered it", () => {
+      const downgrade = vi
+        .fn()
+        .mockReturnValue({ provider: "openai", model: "gpt-4o-mini" });
+      const tracker = new BudgetTracker({ daily: 1 }, "downgrade", downgrade);
+      tracker.recordCost(1.5, "gpt-4o");
+      const result = tracker.checkBefore("openai", "gpt-4o");
+      expect(result?.budget).toBe("daily");
+    });
+
+    it("blocked call does not add reservation", () => {
+      const tracker = new BudgetTracker({ daily: 1 }, "block");
+      tracker.recordCost(1.5, "gpt-4o");
+      // This will throw — no reservation should be added
+      expect(() =>
+        tracker.checkBefore("openai", "gpt-4o", undefined, 0.5),
+      ).toThrow(ToadBudgetExceededError);
+      // After block, state.reservedCost should still be 0
+      expect(tracker.getState().reservedCost).toBe(0);
     });
   });
 

--- a/packages/instrumentation/src/budget/tracker.ts
+++ b/packages/instrumentation/src/budget/tracker.ts
@@ -28,6 +28,7 @@ export class BudgetTracker {
     this.state = {
       date: todayUTC(),
       totalCost: 0,
+      reservedCost: 0,
       perUser: new Map(),
       perModel: new Map(),
     };
@@ -40,6 +41,7 @@ export class BudgetTracker {
       this.state = {
         date: today,
         totalCost: 0,
+        reservedCost: 0,
         perUser: new Map(),
         perModel: new Map(),
       };
@@ -48,40 +50,63 @@ export class BudgetTracker {
 
   /**
    * Check budget BEFORE making an LLM call.
-   * Returns modified provider/model if downgrade mode triggers,
-   * throws ToadBudgetExceededError if block mode triggers,
-   * returns null if no action needed.
+   * - block mode: throws ToadBudgetExceededError if budget is exceeded.
+   * - downgrade mode: returns modified provider/model + budget type that triggered it.
+   * - warn mode: returns null (warning emitted after call via recordCost).
+   *
+   * When estimatedCost is provided, it is added to reservedCost so concurrent
+   * in-flight requests are counted against the budget before their actual cost is known.
+   * Call recordCost with the same estimatedCost to release the reservation.
    */
   checkBefore(
     provider: string,
     model: string,
     userId?: string,
-  ): { provider: string; model: string } | null {
+    estimatedCost = 0,
+  ): {
+    provider: string;
+    model: string;
+    budget: BudgetExceededInfo["budget"];
+  } | null {
     this.resetIfNewDay();
 
-    const exceeded = this.findExceeded(model, userId);
-    if (!exceeded) return null;
+    const exceeded = this.findExceeded(model, userId, estimatedCost);
 
-    if (this.mode === "block") {
-      throw new ToadBudgetExceededError(exceeded);
+    if (exceeded) {
+      if (this.mode === "block") {
+        throw new ToadBudgetExceededError(exceeded);
+      }
+
+      if (this.mode === "downgrade" && this.downgrade) {
+        this.state.reservedCost += estimatedCost;
+        return {
+          ...this.downgrade({ provider, model }),
+          budget: exceeded.budget,
+        };
+      }
     }
 
-    if (this.mode === "downgrade" && this.downgrade) {
-      return this.downgrade({ provider, model });
-    }
-
-    // 'warn' mode — continue, warning emitted after call
+    // warn mode or no budget exceeded: reserve estimated cost and proceed
+    this.state.reservedCost += estimatedCost;
     return null;
   }
 
-  /** Record cost AFTER a successful LLM call. Returns exceeded info if budget was just crossed. */
+  /**
+   * Record cost AFTER a successful LLM call. Returns exceeded info if budget was just crossed.
+   * Pass the same estimatedCost used in checkBefore() to release the reservation atomically.
+   */
   recordCost(
     cost: number,
     model: string,
     userId?: string,
+    reservedAmount = 0,
   ): BudgetExceededInfo | null {
     this.resetIfNewDay();
 
+    this.state.reservedCost = Math.max(
+      0,
+      this.state.reservedCost - reservedAmount,
+    );
     this.state.totalCost += cost;
     this.state.perModel.set(
       model,
@@ -101,10 +126,12 @@ export class BudgetTracker {
   private findExceeded(
     model: string,
     userId?: string,
+    additionalCost = 0,
   ): BudgetExceededInfo | null {
     if (
       this.config.daily !== undefined &&
-      this.state.totalCost >= this.config.daily
+      this.state.totalCost + this.state.reservedCost + additionalCost >=
+        this.config.daily
     ) {
       return {
         budget: "daily",
@@ -141,6 +168,14 @@ export class BudgetTracker {
     return null;
   }
 
+  /** Release a cost reservation when an LLM call fails (no cost was incurred). */
+  releaseReservation(reservedAmount: number) {
+    this.state.reservedCost = Math.max(
+      0,
+      this.state.reservedCost - reservedAmount,
+    );
+  }
+
   /** Get current budget usage as percentage (0-100+). */
   getUsagePercent(): number {
     if (this.config.daily === undefined || this.config.daily === 0) return 0;
@@ -165,6 +200,7 @@ export class BudgetTracker {
     this.state = {
       date: saved.date,
       totalCost: saved.totalCost,
+      reservedCost: 0,
       perUser: new Map(Object.entries(saved.perUser)),
       perModel: new Map(Object.entries(saved.perModel)),
     };

--- a/packages/instrumentation/src/budget/types.ts
+++ b/packages/instrumentation/src/budget/types.ts
@@ -21,6 +21,8 @@ export type DowngradeCallback = (original: {
 export interface BudgetState {
   date: string;
   totalCost: number;
+  /** Sum of estimated costs for in-flight requests (released when recordCost is called). */
+  reservedCost: number;
   perUser: Map<string, number>;
   perModel: Map<string, number>;
 }

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -15,6 +15,8 @@ import {
   recordResponseLatencyPerToken,
 } from "./metrics.js";
 import { getConfig, getBudgetTracker } from "./tracer.js";
+import { calculateCost } from "./pricing.js";
+import { ToadBudgetExceededError } from "../budget/index.js";
 
 /** Input for traceLLMCall — what the user knows before calling the LLM */
 export interface LLMCallInput {
@@ -206,10 +208,19 @@ export async function traceLLMCall(
   const budget = getBudgetTracker();
   let effectiveInput = input;
 
+  // Estimated cost for reservation — reduces race window for concurrent requests.
+  // Uses conservative token estimates; actual cost is reconciled in recordCost.
+  const estimatedCost = budget ? calculateCost(input.model, 500, 200) : 0;
+
   // Budget check BEFORE the LLM call
   if (budget) {
     const userId = input.attributes?.[GEN_AI_ATTRS.USER_ID];
-    const override = budget.checkBefore(input.provider, input.model, userId);
+    const override = budget.checkBefore(
+      input.provider,
+      input.model,
+      userId,
+      estimatedCost,
+    );
     if (override) {
       // Downgrade mode — use modified provider/model
       effectiveInput = {
@@ -217,7 +228,7 @@ export async function traceLLMCall(
         provider: override.provider as LLMSpanAttributes["provider"],
         model: override.model,
       };
-      recordBudgetDowngraded("daily");
+      recordBudgetDowngraded(override.budget);
     }
   }
 
@@ -269,13 +280,14 @@ export async function traceLLMCall(
           );
         }
 
-        // Budget recording AFTER the call
+        // Budget recording AFTER the call — releases the cost reservation
         if (budget) {
           const userId = effectiveInput.attributes?.[GEN_AI_ATTRS.USER_ID];
           const exceeded = budget.recordCost(
             output.cost,
             effectiveInput.model,
             userId,
+            estimatedCost,
           );
           if (exceeded) {
             recordBudgetExceeded(exceeded.budget);
@@ -300,12 +312,14 @@ export async function traceLLMCall(
         );
         recordError(effectiveInput.provider, effectiveInput.model, attrs);
 
-        // If this was a budget block, record the metric
-        if (
-          error instanceof Error &&
-          error.name === "ToadBudgetExceededError"
-        ) {
-          recordBudgetBlocked("daily");
+        // Release cost reservation on any error (no cost was incurred)
+        if (budget) {
+          budget.releaseReservation(estimatedCost);
+        }
+
+        // If this was a budget block, record the metric with the correct budget type
+        if (error instanceof ToadBudgetExceededError) {
+          recordBudgetBlocked(error.budget);
         }
 
         throw error;


### PR DESCRIPTION
Closes #146

## Problem

Concurrent LLM calls all pass `checkBefore()` before any call records its cost, allowing the daily budget to be exceeded under load. Additionally, `recordBudgetDowngraded` and `recordBudgetBlocked` always emitted `"daily"` regardless of which budget type actually triggered.

## Solution

### Race condition — cost reservation

- Added `reservedCost: number` to `BudgetState` to track in-flight estimated costs
- `checkBefore(provider, model, userId, estimatedCost?)` now includes `estimatedCost` in the daily budget check: `totalCost + reservedCost + estimatedCost >= limit`
- On pass, `estimatedCost` is added to `reservedCost` (reservation held until call completes)
- `recordCost(cost, model, userId, reservedAmount?)` releases the reservation atomically when the actual cost is recorded
- `releaseReservation(amount)` added for the error path (failed calls incur no cost)
- `traceLLMCall` pre-estimates cost via `calculateCost(model, 500, 200)` and threads it through both calls

### Hardcoded metric type

- `checkBefore` return type now includes `budget: "daily" | "perUser" | "perModel"` — callers know which limit triggered
- `recordBudgetDowngraded("daily")` → `recordBudgetDowngraded(override.budget)`
- `recordBudgetBlocked("daily")` → `instanceof ToadBudgetExceededError` check + `error.budget`

## Tests

6 new test cases in `budget.test.ts`:
- Concurrent reservation blocks second request over limit
- Reservation released on `recordCost` (success path)
- Reservation released on `releaseReservation` (error path)
- Reservation does not affect `perModel`/`perUser` checks
- Downgrade result includes correct `budget` type
- Block mode does not add reservation to state