### PR TITLE
fix: alerting sequential eval, YAML validation, SMTP caching, rate limiting

### DIFF
--- a/packages/instrumentation/src/__tests__/alert-manager.test.ts
+++ b/packages/instrumentation/src/__tests__/alert-manager.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AlertManager } from "../alerts/manager.js";
+import type { AlertsConfig } from "../alerts/types.js";
+
+vi.mock("../alerts/conditions.js", () => ({
+  evaluateCondition: vi.fn(),
+}));
+
+vi.mock("../alerts/channels.js", () => ({
+  sendToChannel: vi.fn(),
+}));
+
+vi.mock("../alerts/grafana.js", () => ({
+  postGrafanaAnnotation: vi.fn(),
+}));
+
+import { evaluateCondition } from "../alerts/conditions.js";
+import { sendToChannel } from "../alerts/channels.js";
+
+const TRIGGERED = {
+  triggered: true,
+  value: 15,
+  threshold: 10,
+  topModels: [],
+};
+const NOT_TRIGGERED = {
+  triggered: false,
+  value: 3,
+  threshold: 10,
+  topModels: [],
+};
+
+function makeConfig(overrides: Partial<AlertsConfig> = {}): AlertsConfig {
+  return {
+    evalIntervalSeconds: 60,
+    alerts: [
+      {
+        name: "high-cost",
+        metric: "gen_ai.client.request.cost",
+        condition: "> 10",
+        channels: ["slack"],
+      },
+    ],
+    channels: {
+      slack: { type: "slack_webhook", url: "https://hooks.slack.example/test" },
+    },
+    ...overrides,
+  };
+}
+
+// Flush the immediate evaluate() called in start() without advancing the interval
+async function flushImmediate() {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("AlertManager lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(evaluateCondition).mockResolvedValue(NOT_TRIGGERED);
+    vi.mocked(sendToChannel).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("calls evaluate immediately on start()", async () => {
+    const manager = new AlertManager(makeConfig());
+    manager.start();
+    await flushImmediate();
+    expect(evaluateCondition).toHaveBeenCalledTimes(1);
+    manager.stop();
+  });
+
+  it("calls evaluate again on each interval tick", async () => {
+    const manager = new AlertManager(makeConfig({ evalIntervalSeconds: 60 }));
+    manager.start();
+    await flushImmediate();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(evaluateCondition).toHaveBeenCalledTimes(2);
+    manager.stop();
+  });
+
+  it("stop() prevents further evaluations", async () => {
+    const manager = new AlertManager(makeConfig());
+    manager.start();
+    await flushImmediate();
+    manager.stop();
+    await vi.advanceTimersByTimeAsync(120_000);
+    // Only the initial evaluate call
+    expect(evaluateCondition).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps evalIntervalSeconds below minimum to 10s", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const manager = new AlertManager(makeConfig({ evalIntervalSeconds: 2 }));
+    manager.start();
+    await flushImmediate();
+    // Advance 10s — should trigger second eval (interval was clamped to 10s)
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(evaluateCondition).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("below minimum"),
+    );
+    manager.stop();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("AlertManager cooldown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(sendToChannel).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("fires alert when condition is triggered", async () => {
+    vi.mocked(evaluateCondition).mockResolvedValue(TRIGGERED);
+    const manager = new AlertManager(makeConfig());
+    manager.start();
+    await flushImmediate();
+    expect(sendToChannel).toHaveBeenCalledTimes(1);
+    manager.stop();
+  });
+
+  it("does not fire again within cooldown period", async () => {
+    vi.mocked(evaluateCondition).mockResolvedValue(TRIGGERED);
+    const manager = new AlertManager(
+      makeConfig({ evalIntervalSeconds: 60, cooldownMinutes: 30 }),
+    );
+    manager.start();
+    await flushImmediate();
+    // Second tick — still within 30-minute cooldown
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(sendToChannel).toHaveBeenCalledTimes(1);
+    manager.stop();
+  });
+
+  it("fires again after cooldown expires", async () => {
+    vi.mocked(evaluateCondition).mockResolvedValue(TRIGGERED);
+    const manager = new AlertManager(
+      makeConfig({ evalIntervalSeconds: 60, cooldownMinutes: 1 }),
+    );
+    manager.start();
+    await flushImmediate();
+    // Advance past 1-minute cooldown + one eval interval
+    await vi.advanceTimersByTimeAsync(62_000);
+    expect(sendToChannel).toHaveBeenCalledTimes(2);
+    manager.stop();
+  });
+});
+
+describe("AlertManager parallel evaluation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(sendToChannel).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("evaluates all rules even when one Prometheus call fails", async () => {
+    vi.mocked(evaluateCondition)
+      .mockRejectedValueOnce(new Error("Prometheus unreachable"))
+      .mockResolvedValueOnce(TRIGGERED);
+
+    const manager = new AlertManager(
+      makeConfig({
+        alerts: [
+          {
+            name: "rule-a",
+            metric: "gen_ai.client.request.cost",
+            condition: "> 10",
+            channels: ["slack"],
+          },
+          {
+            name: "rule-b",
+            metric: "gen_ai.client.errors",
+            condition: "> 5",
+            channels: ["slack"],
+          },
+        ],
+      }),
+    );
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    manager.start();
+    await flushImmediate();
+
+    // Both rules attempted
+    expect(evaluateCondition).toHaveBeenCalledTimes(2);
+    // rule-b fired despite rule-a failure
+    expect(sendToChannel).toHaveBeenCalledTimes(1);
+    manager.stop();
+  });
+
+  it("evaluates multiple rules in a single cycle", async () => {
+    vi.mocked(evaluateCondition).mockResolvedValue(NOT_TRIGGERED);
+    const manager = new AlertManager(
+      makeConfig({
+        alerts: [
+          {
+            name: "r1",
+            metric: "gen_ai.client.request.cost",
+            condition: "> 10",
+            channels: ["slack"],
+          },
+          {
+            name: "r2",
+            metric: "gen_ai.client.errors",
+            condition: "> 5",
+            channels: ["slack"],
+          },
+          {
+            name: "r3",
+            metric: "gen_ai.client.requests",
+            condition: "> 100",
+            channels: ["slack"],
+          },
+        ],
+      }),
+    );
+    manager.start();
+    await flushImmediate();
+    expect(evaluateCondition).toHaveBeenCalledTimes(3);
+    manager.stop();
+  });
+});
+
+describe("AlertManager channel failure handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(evaluateCondition).mockResolvedValue(TRIGGERED);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("logs error but continues when channel send fails", async () => {
+    vi.mocked(sendToChannel).mockRejectedValue(new Error("Network error"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const manager = new AlertManager(makeConfig());
+    manager.start();
+    await flushImmediate();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to send to channel "slack"'),
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+    manager.stop();
+  });
+
+  it("continues with remaining channels when one fails", async () => {
+    vi.mocked(sendToChannel)
+      .mockRejectedValueOnce(new Error("slack down"))
+      .mockResolvedValueOnce(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const manager = new AlertManager(
+      makeConfig({
+        alerts: [
+          {
+            name: "high-cost",
+            metric: "gen_ai.client.request.cost",
+            condition: "> 10",
+            channels: ["slack", "webhook"],
+          },
+        ],
+        channels: {
+          slack: {
+            type: "slack_webhook",
+            url: "https://hooks.slack.example/test",
+          },
+          webhook: { type: "webhook", url: "https://hooks.example/test" },
+        },
+      }),
+    );
+    manager.start();
+    await flushImmediate();
+    // Both channels were attempted despite first failing
+    expect(sendToChannel).toHaveBeenCalledTimes(2);
+    manager.stop();
+  });
+});
+
+describe("startAlertsFromFile YAML validation", () => {
+  it("catches missing alerts array", async () => {
+    const { startAlertsFromFile } = await import("../alerts/index.js");
+    const { writeFileSync, unlinkSync } = await import("node:fs");
+    const tmpPath = "/tmp/toad-eye-test-config.yaml";
+    writeFileSync(tmpPath, "evalIntervalSeconds: 60\n");
+    expect(() => startAlertsFromFile(tmpPath)).toThrow(
+      'missing required "alerts" array',
+    );
+    unlinkSync(tmpPath);
+  });
+
+  it("catches rule missing required field", async () => {
+    const { startAlertsFromFile } = await import("../alerts/index.js");
+    const { writeFileSync, unlinkSync } = await import("node:fs");
+    const tmpPath = "/tmp/toad-eye-test-config2.yaml";
+    writeFileSync(
+      tmpPath,
+      `alerts:\n  - name: broken-rule\n    metric: gen_ai.client.request.cost\n`,
+    );
+    expect(() => startAlertsFromFile(tmpPath)).toThrow(
+      'missing required string field "condition"',
+    );
+    unlinkSync(tmpPath);
+  });
+
+  it("catches rule with no channels", async () => {
+    const { startAlertsFromFile } = await import("../alerts/index.js");
+    const { writeFileSync, unlinkSync } = await import("node:fs");
+    const tmpPath = "/tmp/toad-eye-test-config3.yaml";
+    writeFileSync(
+      tmpPath,
+      `alerts:\n  - name: no-channels\n    metric: gen_ai.client.request.cost\n    condition: "> 10"\n    channels: []\n`,
+    );
+    expect(() => startAlertsFromFile(tmpPath)).toThrow(
+      "must have at least one channel",
+    );
+    unlinkSync(tmpPath);
+  });
+});

--- a/packages/instrumentation/src/alerts/channels.ts
+++ b/packages/instrumentation/src/alerts/channels.ts
@@ -1,5 +1,16 @@
 import type { AlertChannelConfig, FiredAlert } from "./types.js";
 
+// Cache nodemailer transporters by connection identity to avoid creating a new
+// SMTP connection for every alert (frequent alerts would exhaust connection pools).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const smtpTransporterCache = new Map<string, any>();
+
+function smtpCacheKey(
+  config: Extract<AlertChannelConfig, { type: "email" }>,
+): string {
+  return `${config.host}:${config.port}:${config.user}`;
+}
+
 function formatMessage(alert: FiredAlert): string {
   const topModelsText =
     alert.topModels.length > 0
@@ -70,19 +81,25 @@ async function sendEmail(
   config: Extract<AlertChannelConfig, { type: "email" }>,
   alert: FiredAlert,
 ) {
-  let createTransport: (typeof import("nodemailer"))["createTransport"];
-  try {
-    ({ createTransport } = await import("nodemailer"));
-  } catch {
-    throw new Error(
-      "toad-eye: email alerts require nodemailer — install it: npm install nodemailer",
-    );
+  const key = smtpCacheKey(config);
+  let transporter = smtpTransporterCache.get(key);
+
+  if (!transporter) {
+    let createTransport: (typeof import("nodemailer"))["createTransport"];
+    try {
+      ({ createTransport } = await import("nodemailer"));
+    } catch {
+      throw new Error(
+        "toad-eye: email alerts require nodemailer — install it: npm install nodemailer",
+      );
+    }
+    transporter = createTransport({
+      host: config.host,
+      port: config.port,
+      auth: { user: config.user, pass: config.password },
+    });
+    smtpTransporterCache.set(key, transporter);
   }
-  const transporter = createTransport({
-    host: config.host,
-    port: config.port,
-    auth: { user: config.user, pass: config.password },
-  });
   const to =
     typeof config.to === "string"
       ? config.to

--- a/packages/instrumentation/src/alerts/index.ts
+++ b/packages/instrumentation/src/alerts/index.ts
@@ -33,11 +33,40 @@ function interpolateConfig(obj: unknown): unknown {
   return obj;
 }
 
+function validateConfig(config: unknown): asserts config is AlertsConfig {
+  if (typeof config !== "object" || config === null) {
+    throw new Error("toad-eye: alerts config must be an object");
+  }
+  const c = config as Record<string, unknown>;
+  if (!Array.isArray(c["alerts"])) {
+    throw new Error('toad-eye: alerts config missing required "alerts" array');
+  }
+  for (const rule of c["alerts"] as unknown[]) {
+    if (typeof rule !== "object" || rule === null) {
+      throw new Error("toad-eye: each alert rule must be an object");
+    }
+    const r = rule as Record<string, unknown>;
+    for (const field of ["name", "metric", "condition"] as const) {
+      if (typeof r[field] !== "string" || !r[field]) {
+        throw new Error(
+          `toad-eye: alert rule missing required string field "${field}"`,
+        );
+      }
+    }
+    if (!Array.isArray(r["channels"]) || r["channels"].length === 0) {
+      throw new Error(
+        `toad-eye: alert rule "${String(r["name"])}" must have at least one channel`,
+      );
+    }
+  }
+}
+
 export function startAlertsFromFile(configPath: string): AlertManager {
   const raw = readFileSync(configPath, "utf-8");
-  const parsed = yaml.parse(raw) as AlertsConfig;
-  const config = interpolateConfig(parsed) as AlertsConfig;
-  const manager = new AlertManager(config);
+  const parsed: unknown = yaml.parse(raw);
+  const interpolated = interpolateConfig(parsed);
+  validateConfig(interpolated);
+  const manager = new AlertManager(interpolated);
   manager.start();
   return manager;
 }

--- a/packages/instrumentation/src/alerts/manager.ts
+++ b/packages/instrumentation/src/alerts/manager.ts
@@ -7,6 +7,7 @@ const DEFAULT_PROMETHEUS_URL = "http://localhost:9090";
 const DEFAULT_GRAFANA_URL = "http://localhost:3100";
 const DEFAULT_EVAL_INTERVAL_SECONDS = 60;
 const DEFAULT_COOLDOWN_MINUTES = 30;
+const MIN_EVAL_INTERVAL_SECONDS = 10;
 
 export class AlertManager {
   private readonly config: AlertsConfig;
@@ -18,12 +19,19 @@ export class AlertManager {
   }
 
   start() {
-    const intervalMs =
-      (this.config.evalIntervalSeconds ?? DEFAULT_EVAL_INTERVAL_SECONDS) * 1000;
+    const configured =
+      this.config.evalIntervalSeconds ?? DEFAULT_EVAL_INTERVAL_SECONDS;
+    const clampedSeconds = Math.max(configured, MIN_EVAL_INTERVAL_SECONDS);
+    if (configured < MIN_EVAL_INTERVAL_SECONDS) {
+      console.warn(
+        `[toad-eye alerts] evalIntervalSeconds ${configured} is below minimum ${MIN_EVAL_INTERVAL_SECONDS}s — using ${clampedSeconds}s`,
+      );
+    }
+    const intervalMs = clampedSeconds * 1000;
     this.intervalId = setInterval(() => void this.evaluate(), intervalMs);
     void this.evaluate();
     console.log(
-      `[toad-eye alerts] Started — ${this.config.alerts.length} rule(s), eval every ${intervalMs / 1000}s`,
+      `[toad-eye alerts] Started — ${this.config.alerts.length} rule(s), eval every ${clampedSeconds}s`,
     );
   }
 
@@ -50,36 +58,57 @@ export class AlertManager {
     const prometheusUrl = this.config.prometheusUrl ?? DEFAULT_PROMETHEUS_URL;
     const grafanaUrl = this.config.grafanaUrl ?? DEFAULT_GRAFANA_URL;
 
-    for (const rule of this.config.alerts) {
-      if (this.isInCooldown(rule)) continue;
+    // Evaluate all rules in parallel — each rule is independent
+    await Promise.allSettled(
+      this.config.alerts.map((rule) =>
+        this.evaluateRule(prometheusUrl, grafanaUrl, rule),
+      ),
+    );
+  }
 
-      const result = await evaluateCondition(prometheusUrl, rule);
-      if (!result?.triggered) continue;
+  private async evaluateRule(
+    prometheusUrl: string,
+    grafanaUrl: string,
+    rule: AlertRule,
+  ) {
+    if (this.isInCooldown(rule)) return;
 
-      this.cooldowns.set(rule.name, Date.now());
-
-      const firedAlert: FiredAlert = {
-        rule,
-        value: result.value,
-        threshold: result.threshold,
-        topModels: result.topModels,
-        firedAt: new Date(),
-      };
-
-      console.log(
-        `[toad-eye alerts] 🚨 "${rule.name}" fired — value=${result.value.toFixed(4)}, threshold=${result.threshold}`,
+    let result: Awaited<ReturnType<typeof evaluateCondition>>;
+    try {
+      result = await evaluateCondition(prometheusUrl, rule);
+    } catch (err) {
+      console.error(
+        `[toad-eye alerts] Failed to evaluate rule "${rule.name}":`,
+        err,
       );
-
-      await Promise.allSettled([
-        this.fireChannels(firedAlert),
-        this.postAnnotation(
-          grafanaUrl,
-          firedAlert.rule.name,
-          firedAlert.value,
-          firedAlert.threshold,
-        ),
-      ]);
+      return;
     }
+
+    if (!result?.triggered) return;
+
+    this.cooldowns.set(rule.name, Date.now());
+
+    const firedAlert: FiredAlert = {
+      rule,
+      value: result.value,
+      threshold: result.threshold,
+      topModels: result.topModels,
+      firedAt: new Date(),
+    };
+
+    console.log(
+      `[toad-eye alerts] 🚨 "${rule.name}" fired — value=${result.value.toFixed(4)}, threshold=${result.threshold}`,
+    );
+
+    await Promise.allSettled([
+      this.fireChannels(firedAlert),
+      this.postAnnotation(
+        grafanaUrl,
+        firedAlert.rule.name,
+        firedAlert.value,
+        firedAlert.threshold,
+      ),
+    ]);
   }
 
   private async fireChannels(alert: FiredAlert) {


### PR DESCRIPTION
Closes #147

## Problem

Five issues in the alerting subsystem found during technical audit.

## Changes

### 1. Sequential → parallel rule evaluation (`alerts/manager.ts`)

`evaluate()` used a `for...of` loop with `await` — 10 rules × 3 HTTP calls = 30 sequential Prometheus requests. Extracted `evaluateRule()` private method; `evaluate()` now uses `Promise.allSettled()` to evaluate all rules concurrently. Each rule's Prometheus error is caught and logged without affecting other rules.

### 2. YAML config validation (`alerts/index.ts`)

`yaml.parse(raw) as AlertsConfig` had no runtime validation — malformed configs crashed deep inside evaluation with confusing errors. `startAlertsFromFile()` now validates before constructing `AlertManager`:
- config root must be an object
- `alerts` array must be present
- each rule must have `name`, `metric`, `condition` (non-empty strings)
- each rule must have at least one channel

### 3. SMTP transporter caching (`alerts/channels.ts`)

`sendEmail()` created a new `nodemailer` transporter (= new SMTP connection) per alert send. Frequent alerts would exhaust connection pools. Now caches transporters by `host:port:user` key — reuses existing connection.

### 4. Minimum eval interval guard (`alerts/manager.ts`)

`evalIntervalSeconds` below 10s is clamped to 10s with a `console.warn`. Prevents accidental Prometheus floods from misconfigured very low intervals.

### 5. AlertManager lifecycle tests (`__tests__/alert-manager.test.ts`, 14 tests)

Tests with `vi.useFakeTimers()` / `advanceTimersByTimeAsync`:
- `start()` fires `evaluate()` immediately and on every interval tick
- `stop()` clears the interval — no further evaluations
- `evalIntervalSeconds` clamping triggers `console.warn`
- Cooldown: alert not re-fired within cooldown period
- Cooldown: alert fires again after cooldown expires
- Parallel: all rules evaluated even if one Prometheus call fails
- Channel failure: error logged, remaining channels still attempted (2 channels, first fails → second still called)