### PR TITLE
fix(dx): surface silent failures via console.warn (#150)

### DIFF
--- a/packages/instrumentation/src/__tests__/registry.test.ts
+++ b/packages/instrumentation/src/__tests__/registry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Import registry directly to test enableAll behavior
+import {
+  enableAll,
+  register,
+  disableAll,
+} from "../instrumentations/registry.js";
+import type { Instrumentation } from "../instrumentations/types.js";
+
+function makeInst(
+  name: "openai" | "anthropic" | "gemini",
+  enables: boolean,
+): Instrumentation {
+  return {
+    name,
+    enable: vi.fn(() => enables),
+    disable: vi.fn(),
+  };
+}
+
+describe("enableAll — user-visible warnings", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    disableAll();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    disableAll();
+  });
+
+  it("warns with console.warn when provider is unknown (not registered)", () => {
+    // @ts-expect-error — intentionally passing unknown provider
+    enableAll(["opanai"]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("unknown provider"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("opanai"));
+  });
+
+  it("includes valid provider list in the unknown provider warning", () => {
+    // @ts-expect-error — intentionally passing unknown provider
+    enableAll(["groq"]);
+
+    const call = warnSpy.mock.calls[0]?.[0] as string;
+    expect(call).toMatch(/valid providers:/);
+  });
+
+  it("warns with console.warn when SDK is not installed", () => {
+    const inst = makeInst("openai", false); // enable() returns false = SDK not found
+    register(inst);
+    enableAll(["openai"]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"openai" SDK not found'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("npm install openai"),
+    );
+  });
+
+  it("includes correct package name hint for gemini", () => {
+    const inst = makeInst("gemini", false);
+    register(inst);
+    enableAll(["gemini"]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("@google/generative-ai"),
+    );
+  });
+
+  it("does not warn when provider is successfully patched", () => {
+    const inst = makeInst("anthropic", true);
+    register(inst);
+    enableAll(["anthropic"]);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not re-warn when provider is already active", () => {
+    const inst = makeInst("openai", true);
+    register(inst);
+    enableAll(["openai"]);
+    enableAll(["openai"]); // second call — already active
+
+    expect(inst.enable).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -54,8 +54,8 @@ describe("traceLLMCall", () => {
     mockSpan.setStatus.mockClear();
   });
 
-  it("warns via diag when called without initObservability", async () => {
-    const { diag } = await import("@opentelemetry/api");
+  it("warns via console.warn when called without initObservability", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockConfig = undefined as unknown as Record<string, unknown>;
 
     await traceLLMCall(
@@ -68,10 +68,11 @@ describe("traceLLMCall", () => {
       }),
     );
 
-    expect(diag.warn).toHaveBeenCalledWith(
+    expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("initObservability"),
     );
 
+    warnSpy.mockRestore();
     mockConfig = {};
   });
 

--- a/packages/instrumentation/src/__tests__/tracer.test.ts
+++ b/packages/instrumentation/src/__tests__/tracer.test.ts
@@ -152,16 +152,17 @@ describe("initObservability — cloud mode", () => {
 
 describe("singleton lifecycle", () => {
   it("warns when initObservability is called twice", async () => {
-    const { diag } = await import("@opentelemetry/api");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     await shutdown();
 
     initObservability({ serviceName: "first" });
     initObservability({ serviceName: "second" });
 
-    expect(diag.warn).toHaveBeenCalledWith(
+    expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("already called"),
     );
 
+    warnSpy.mockRestore();
     await shutdown();
   });
 

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { trace, diag, type Span, SpanStatusCode } from "@opentelemetry/api";
+import { trace, type Span, SpanStatusCode } from "@opentelemetry/api";
 import type { LLMSpanAttributes, LLMProvider } from "../types/index.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "../types/index.js";
 import {
@@ -53,7 +53,7 @@ function sha256(text: string): string {
   }
 
   if (config?.hashContent && !config.salt && !saltWarningEmitted) {
-    diag.warn(
+    console.warn(
       "toad-eye: hashContent is enabled without salt — short strings may be reversible. Set salt in config for stronger privacy.",
     );
     saltWarningEmitted = true;
@@ -200,7 +200,7 @@ export async function traceLLMCall(
   fn: () => Promise<LLMCallOutput>,
 ): Promise<LLMCallOutput> {
   if (!getConfig()) {
-    diag.warn(
+    console.warn(
       "toad-eye: traceLLMCall called before initObservability() — no telemetry will be recorded.",
     );
   }

--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -8,7 +8,6 @@ import {
   ParentBasedSampler,
 } from "@opentelemetry/sdk-trace-node";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-import { diag } from "@opentelemetry/api";
 import type { ToadEyeConfig } from "../types/index.js";
 import { initMetrics, resetMetrics } from "./metrics.js";
 import { resetCustomPricing } from "./pricing.js";
@@ -68,7 +67,7 @@ function resolveTransport(config: ToadEyeConfig) {
 
 export function initObservability(config: ToadEyeConfig) {
   if (sdk) {
-    diag.warn(
+    console.warn(
       "toad-eye: initObservability() already called. Call shutdown() first to reconfigure.",
     );
     return;
@@ -121,6 +120,20 @@ export function initObservability(config: ToadEyeConfig) {
   sdk.start();
   currentConfig = config;
   initMetrics();
+
+  // Non-blocking connectivity check — warns the user if the OTel Collector is unreachable.
+  // Fire-and-forget: does not block initObservability(). Cloud mode skips this check.
+  if (!isCloudMode) {
+    void fetch(`${endpoint}/v1/traces`, {
+      method: "POST",
+      body: "[]",
+      signal: AbortSignal.timeout(2000),
+    }).catch(() => {
+      console.warn(
+        `toad-eye: cannot reach OTel Collector at ${endpoint} — no telemetry will be exported. Is the stack running? Run: npx toad-eye up`,
+      );
+    });
+  }
 
   if (isCloudMode) {
     const masked = config.apiKey

--- a/packages/instrumentation/src/instrumentations/registry.ts
+++ b/packages/instrumentation/src/instrumentations/registry.ts
@@ -1,4 +1,3 @@
-import { diag } from "@opentelemetry/api";
 import type { LLMProvider } from "../types/index.js";
 import type { Instrumentation } from "./types.js";
 
@@ -10,21 +9,26 @@ export function register(inst: Instrumentation) {
 }
 
 export function enableAll(providers: readonly LLMProvider[]) {
+  const validProviders = Array.from(instrumentations.keys()).join(", ");
+
   for (const name of providers) {
     if (active.has(name)) continue;
 
     const inst = instrumentations.get(name);
     if (!inst) {
-      diag.warn(`toad-eye: unknown provider "${name}", skipping`);
+      console.warn(
+        `toad-eye: unknown provider "${name}" — valid providers: ${validProviders}`,
+      );
       continue;
     }
 
     const patched = inst.enable();
     if (patched) {
       active.add(name);
-      diag.debug(`toad-eye: auto-instrumented ${name}`);
     } else {
-      diag.debug(`toad-eye: ${name} SDK not found, skipping`);
+      console.warn(
+        `toad-eye: "${name}" SDK not found — install it to enable auto-instrumentation: npm install ${name === "gemini" ? "@google/generative-ai" : name}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Problem

OTel `diag.*` is invisible to users by default — they only see it if they explicitly configure OTel diagnostics. This meant critical warnings (unknown provider, SDK not installed, double-init) were silently swallowed.

## Changes

- **`registry.ts`**: `diag.warn/debug` → `console.warn` for unknown provider (includes valid provider list) and SDK not found (includes `npm install <pkg>` hint with correct package name for gemini: `@google/generative-ai`)
- **`spans.ts`**: `diag.warn` → `console.warn` for `traceLLMCall`-before-init and `hashContent`-without-salt warnings
- **`tracer.ts`**: `diag.warn` → `console.warn` for double-init; added non-blocking OTel Collector reachability check on startup (self-hosted mode only)
- **Tests**: Updated `spans.test.ts` and `tracer.test.ts` to spy on `console.warn`; added `registry.test.ts` with 6 tests covering all warning paths

## Test plan

- [x] `npx vitest run` — all 68 tests pass
- [x] Manual: pass unknown provider → `console.warn` with valid list visible in terminal
- [x] Manual: SDK not installed → `console.warn` with `npm install` hint
- [x] Manual: call `initObservability` twice → `console.warn` about double-init
- [x] Manual: start without OTel Collector → reachability warning appears after ~2s

Closes #150