### PR TITLE
dx: improve traceLLMCall API ergonomics (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,34 @@ Vercel AI SDK uses a SpanProcessor (not monkey-patching) — add `instrument: ['
 <details>
 <summary>Manual instrumentation (custom providers)</summary>
 
+Use `traceLLMCall` when you need to instrument a provider not in the auto-instrument list, or want explicit control over span data:
+
 ```typescript
+import OpenAI from "openai";
 import { initObservability, traceLLMCall } from "toad-eye";
 
 initObservability({ serviceName: "my-app" });
 
+const openai = new OpenAI();
+
 const result = await traceLLMCall(
-  { provider: "anthropic", model: "claude-sonnet-4-20250514", prompt: "hello" },
-  () => callYourLLM(),
+  { provider: "openai", model: "gpt-4o", prompt: "Hello" },
+  async () => {
+    const res = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    return {
+      completion: res.choices[0]?.message.content ?? "",
+      inputTokens: res.usage?.prompt_tokens ?? 0,
+      outputTokens: res.usage?.completion_tokens ?? 0,
+      // cost is auto-calculated from model + tokens if omitted
+    };
+  },
 );
 ```
+
+> Or skip this entirely — use `instrument: ['openai']` for zero-code instrumentation.
 
 </details>
 
@@ -126,6 +144,21 @@ Structured tracing for ReAct agents with multi-agent support, handoffs, and loop
 import { traceAgentQuery } from "toad-eye";
 
 const result = await traceAgentQuery(
+  "What's the weather like?",
+  async (step) => {
+    step({ type: "think", stepNumber: 1, content: "Need weather data" });
+    const data = await getWeather();
+    step({ type: "answer", stepNumber: 2, content: data.summary });
+    return { answer: data.summary };
+  },
+);
+```
+
+<details>
+<summary>Full ReAct pattern (think → act → observe → answer)</summary>
+
+```typescript
+const result = await traceAgentQuery(
   "Is anything dangerous near Earth?",
   async (step) => {
     step({
@@ -149,6 +182,8 @@ const result = await traceAgentQuery(
   },
 );
 ```
+
+</details>
 
 ## FinOps attribution
 

--- a/packages/instrumentation/src/__tests__/registry.test.ts
+++ b/packages/instrumentation/src/__tests__/registry.test.ts
@@ -35,8 +35,7 @@ describe("enableAll — user-visible warnings", () => {
   });
 
   it("warns with console.warn when provider is unknown (not registered)", async () => {
-    // @ts-expect-error — intentionally passing unknown provider
-    await enableAll(["opanai"]);
+    await enableAll(["opanai"]); // valid string, but not registered in the registry
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("unknown provider"),
@@ -45,8 +44,7 @@ describe("enableAll — user-visible warnings", () => {
   });
 
   it("includes valid provider list in the unknown provider warning", async () => {
-    // @ts-expect-error — intentionally passing unknown provider
-    await enableAll(["groq"]);
+    await enableAll(["groq"]); // valid string, but not registered in the registry
 
     const call = warnSpy.mock.calls[0]?.[0] as string;
     expect(call).toMatch(/valid providers:/);

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -33,7 +33,8 @@ export interface LLMCallOutput {
   readonly completion: string;
   readonly inputTokens: number;
   readonly outputTokens: number;
-  readonly cost: number;
+  /** Cost in USD. If omitted, auto-calculated from model pricing table. */
+  readonly cost?: number | undefined;
 }
 
 const tracer = trace.getTracer(INSTRUMENTATION_NAME);
@@ -166,6 +167,7 @@ function setSuccessAttributes(
   span: Span,
   input: LLMCallInput,
   output: LLMCallOutput,
+  resolvedCost: number,
 ) {
   const completion = processContent(output.completion);
   span.setAttributes({
@@ -173,7 +175,7 @@ function setSuccessAttributes(
     [GEN_AI_ATTRS.RESPONSE_MODEL]: input.model,
     [GEN_AI_ATTRS.INPUT_TOKENS]: output.inputTokens,
     [GEN_AI_ATTRS.OUTPUT_TOKENS]: output.outputTokens,
-    [GEN_AI_ATTRS.COST]: output.cost,
+    [GEN_AI_ATTRS.COST]: resolvedCost,
     [GEN_AI_ATTRS.STATUS]: "success",
     [GEN_AI_ATTRS.FINISH_REASONS]: ["stop"],
   });
@@ -242,8 +244,15 @@ export async function traceLLMCall(
         const output = await fn();
         const duration = performance.now() - start;
         const attrs = resolveAttributes(effectiveInput);
+        const resolvedCost =
+          output.cost ??
+          calculateCost(
+            effectiveInput.model,
+            output.inputTokens,
+            output.outputTokens,
+          );
 
-        setSuccessAttributes(span, effectiveInput, output);
+        setSuccessAttributes(span, effectiveInput, output, resolvedCost);
         recordBaseMetrics(
           duration,
           effectiveInput.provider,
@@ -251,7 +260,7 @@ export async function traceLLMCall(
           attrs,
         );
         recordRequestCost(
-          output.cost,
+          resolvedCost,
           effectiveInput.provider,
           effectiveInput.model,
           attrs,
@@ -284,7 +293,7 @@ export async function traceLLMCall(
         if (budget) {
           const userId = effectiveInput.attributes?.[GEN_AI_ATTRS.USER_ID];
           const exceeded = budget.recordCost(
-            output.cost,
+            resolvedCost,
             effectiveInput.model,
             userId,
             estimatedCost,

--- a/packages/instrumentation/src/types/providers.ts
+++ b/packages/instrumentation/src/types/providers.ts
@@ -2,7 +2,7 @@
  * LLM providers supported by toad-eye.
  * Values follow OTel GenAI semconv `gen_ai.provider.name`.
  */
-export type LLMProvider = "anthropic" | "gemini" | "openai";
+export type LLMProvider = "anthropic" | "gemini" | "openai" | (string & {});
 
 /**
  * All instrumentable targets — includes LLM providers + framework SDKs.


### PR DESCRIPTION
## Changes

### `cost` is now optional in `LLMCallOutput`

Users no longer need to import and call `calculateCost` manually:

```ts
// Before
return {
  completion: res.choices[0]?.message.content ?? "",
  inputTokens: res.usage?.prompt_tokens ?? 0,
  outputTokens: res.usage?.completion_tokens ?? 0,
  cost: calculateCost("gpt-4o", inputTokens, outputTokens), // why do I have to do this?
};

// After — cost is auto-calculated from model pricing table
return {
  completion: res.choices[0]?.message.content ?? "",
  inputTokens: res.usage?.prompt_tokens ?? 0,
  outputTokens: res.usage?.completion_tokens ?? 0,
};
```

### `LLMProvider` widened with `(string & {})`

Custom providers (Azure OpenAI, Groq, Together, etc.) no longer cause TypeScript errors:

```ts
// Before: TS error — not assignable to "anthropic" | "gemini" | "openai"
provider: "azure-openai"

// After: valid, warned at runtime only if not registered in the registry
provider: "azure-openai"
```

### README improvements

- Manual instrumentation example replaced — `callYourLLM()` → real OpenAI example with correct return shape + note that auto-instrumentation is simpler
- Agent observability: 20-line ReAct example collapsed into `<details>`, 4-line minimal example shown first

## Test plan

- [x] `npx vitest run` — 565 tests pass
- [x] `npx tsc --noEmit` — no errors
- [x] Manual: omit `cost` from `traceLLMCall` output → cost auto-calculated and recorded in span
- [x] Manual: pass `provider: "groq"` → no TS error, runtime warns "unknown provider"

Closes #152