### PR TITLE
dx: progressive disclosure — subpath exports, feature table, privacy ref (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,24 @@ Open [localhost:3100](http://localhost:3100) (Grafana, admin/admin) to see your 
 | **8 Grafana dashboards** | Overview, Cost, Latency, Errors, Model Comparison, FinOps, Provider Health, Agent Workflow |
 | **Cost tracking**        | Per-request USD cost, daily totals, projected monthly spend                                |
 | **Budget guards**        | Daily/per-user/per-model spend limits — warn, block, or auto-downgrade                     |
-| **Multi-agent tracing**  | ReAct steps, handoffs, loop detection, maxSteps guard                                      |
-| **Shadow guardrails**    | Record what _would_ be blocked without blocking — tune thresholds on live traffic          |
-| **Quality proxy**        | Empty response rate, latency per token — zero-dependency quality metrics                   |
-| **Semantic drift**       | Detect silent quality degradation via embedding comparison                                 |
 | **Privacy controls**     | Built-in PII redaction (email, SSN, CC, phone), hashing, content masking                   |
-| **Tail sampling**        | Keep 100% errors + slow traces, sample healthy traffic via OTel Collector                  |
-| **Alerting**             | Cost spikes, latency anomalies, error rate — via Telegram, Slack, email, webhook           |
-| **FinOps attribution**   | Break down costs by team, user, feature, environment                                       |
-| **TTFT metric**          | Time To First Token for streaming — separate from total duration                           |
-| **Trace export**         | Convert production Jaeger traces into regression test cases                                |
+
+<details>
+<summary>Advanced features</summary>
+
+| Feature                 | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| **Multi-agent tracing** | ReAct steps, handoffs, loop detection, maxSteps guard                             |
+| **Shadow guardrails**   | Record what _would_ be blocked without blocking — tune thresholds on live traffic |
+| **Quality proxy**       | Empty response rate, latency per token — zero-dependency quality metrics          |
+| **Semantic drift**      | Detect silent quality degradation via embedding comparison                        |
+| **Tail sampling**       | Keep 100% errors + slow traces, sample healthy traffic via OTel Collector         |
+| **Alerting**            | Cost spikes, latency anomalies, error rate — via Telegram, Slack, email, webhook  |
+| **FinOps attribution**  | Break down costs by team, user, feature, environment                              |
+| **TTFT metric**         | Time To First Token for streaming — separate from total duration                  |
+| **Trace export**        | Convert production Jaeger traces into regression test cases                       |
+
+</details>
 
 ## Auto-instrumentation 🤖
 
@@ -241,6 +249,14 @@ monitor.checkInBackground(response, "openai", "gpt-4o");
 ```
 
 ### Privacy controls
+
+| Goal                        | Config                           |
+| --------------------------- | -------------------------------- |
+| Don't store text at all     | `recordContent: false`           |
+| Remove common PII           | `redactDefaults: true`           |
+| Remove custom patterns      | `redactPatterns: [/regex/g]`     |
+| Store hashes only (no text) | `hashContent: true, salt: "..."` |
+| Audit what was masked       | `auditMasking: true`             |
 
 ```typescript
 initObservability({

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -5,6 +5,28 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./alerts": {
+      "import": "./dist/alerts/index.js",
+      "types": "./dist/alerts/index.d.ts"
+    },
+    "./drift": {
+      "import": "./dist/drift/index.js",
+      "types": "./dist/drift/index.d.ts"
+    },
+    "./export": {
+      "import": "./dist/export.js",
+      "types": "./dist/export.d.ts"
+    },
+    "./vercel": {
+      "import": "./dist/vercel.js",
+      "types": "./dist/vercel.d.ts"
+    }
+  },
   "bin": {
     "toad-eye": "dist/cli.js"
   },


### PR DESCRIPTION
## Changes

### Subpath exports (`package.json`)

Users can now import advanced modules directly instead of seeing 27 exports in IDE autocomplete:

```ts
import { initObservability } from "toad-eye";          // core — unchanged
import { AlertManager } from "toad-eye/alerts";
import { createDriftMonitor } from "toad-eye/drift";
import { exportTrace } from "toad-eye/export";
import { withToadEye } from "toad-eye/vercel";
```

The main `.` export is unchanged — fully backward compatible.

### Feature table split

14-row table → 5 core features visible, 9 advanced in `<details>`. First impression: _"this is simple."_

### Privacy quick-reference table

Maps user goals to config options — no need to read source to understand the order of operations:

| Goal                        | Config                         |
| --------------------------- | ------------------------------ |
| Don't store text at all     | `recordContent: false`         |
| Remove common PII           | `redactDefaults: true`         |
| Remove custom patterns      | `redactPatterns: [/regex/g]`   |
| Store hashes only (no text) | `hashContent: true, salt: "…"` |
| Audit what was masked       | `auditMasking: true`           |

## Test plan

- [x] `npx vitest run` — 565 tests pass
- [x] `npx tsc --noEmit` — no errors
- [x] `import { AlertManager } from "toad-eye/alerts"` resolves correctly after build

Closes #153