### PR TITLE
feat(semconv): align span names with OTel GenAI spec (#166)

### DIFF
--- a/packages/instrumentation/src/__tests__/agent.test.ts
+++ b/packages/instrumentation/src/__tests__/agent.test.ts
@@ -8,14 +8,23 @@ const mockSpan = {
   end: vi.fn(),
 };
 
+let lastSpanName = "";
+let lastActiveSpanName = "";
+
 vi.mock("@opentelemetry/api", () => ({
   trace: {
     getTracer: () => ({
-      startSpan: (_name: string) => mockSpan,
+      startSpan: (name: string) => {
+        lastSpanName = name;
+        return mockSpan;
+      },
       startActiveSpan: (
-        _name: string,
+        name: string,
         fn: (span: typeof mockSpan) => unknown,
-      ) => fn(mockSpan),
+      ) => {
+        lastActiveSpanName = name;
+        return fn(mockSpan);
+      },
     }),
   },
   SpanStatusCode: { OK: 0, ERROR: 2 },
@@ -43,6 +52,26 @@ describe("traceAgentStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig = {};
+    lastSpanName = "";
+    lastActiveSpanName = "";
+  });
+
+  it("uses execute_tool span name for act steps with toolName", () => {
+    traceAgentStep({ type: "act", stepNumber: 1, toolName: "web-search" });
+
+    expect(lastSpanName).toBe("execute_tool web-search");
+  });
+
+  it("uses gen_ai.agent.step.{type} span name for non-act steps", () => {
+    traceAgentStep({ type: "think", stepNumber: 1 });
+
+    expect(lastSpanName).toBe("gen_ai.agent.step.think");
+  });
+
+  it("uses gen_ai.agent.step.act span name for act steps without toolName", () => {
+    traceAgentStep({ type: "act", stepNumber: 1 });
+
+    expect(lastSpanName).toBe("gen_ai.agent.step.act");
   });
 
   it("creates a span with step type and number", () => {
@@ -109,6 +138,14 @@ describe("traceAgentQuery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig = {};
+    lastSpanName = "";
+    lastActiveSpanName = "";
+  });
+
+  it("uses invoke_agent span name", async () => {
+    await traceAgentQuery("test query", async () => "result");
+
+    expect(lastActiveSpanName).toBe("invoke_agent");
   });
 
   it("returns the result from the callback", async () => {

--- a/packages/instrumentation/src/__tests__/spans.test.ts
+++ b/packages/instrumentation/src/__tests__/spans.test.ts
@@ -7,15 +7,20 @@ const mockSpan = {
   end: vi.fn(),
 };
 
+let lastActiveSpanName = "";
+
 // Mock tracer before importing spans
 vi.mock("@opentelemetry/api", () => {
   return {
     trace: {
       getTracer: () => ({
         startActiveSpan: (
-          _name: string,
+          name: string,
           fn: (span: typeof mockSpan) => unknown,
-        ) => fn(mockSpan),
+        ) => {
+          lastActiveSpanName = name;
+          return fn(mockSpan);
+        },
       }),
     },
     SpanStatusCode: { OK: 0, ERROR: 2 },
@@ -52,6 +57,20 @@ describe("traceLLMCall", () => {
     mockConfig = {};
     mockSpan.setAttributes.mockClear();
     mockSpan.setStatus.mockClear();
+    lastActiveSpanName = "";
+  });
+
+  it("uses OTel GenAI span name: chat {model}", async () => {
+    await traceLLMCall(
+      { provider: "openai", model: "gpt-4o", prompt: "hello" },
+      async () => ({
+        completion: "world",
+        inputTokens: 10,
+        outputTokens: 5,
+      }),
+    );
+
+    expect(lastActiveSpanName).toBe("chat gpt-4o");
   });
 
   it("warns via console.warn when called without initObservability", async () => {

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -13,7 +13,11 @@ const DEFAULT_MAX_STEPS = 25;
  * Supports: think, act, observe, answer, handoff.
  */
 function traceAgentStep(input: AgentStepInput) {
-  const span = tracer.startSpan(`agent.step.${input.type}`);
+  const spanName =
+    input.type === "act" && input.toolName !== undefined
+      ? `execute_tool ${input.toolName}`
+      : `gen_ai.agent.step.${input.type}`;
+  const span = tracer.startSpan(spanName);
 
   const config = getConfig();
   const recordContent = config?.recordContent !== false;
@@ -74,7 +78,7 @@ export async function traceAgentQuery<T>(
   fn: (step: (input: AgentStepInput) => void) => Promise<T>,
   options?: AgentQueryOptions,
 ): Promise<T> {
-  return tracer.startActiveSpan(`agent.query`, async (span) => {
+  return tracer.startActiveSpan(`invoke_agent`, async (span) => {
     const config = getConfig();
     const recordContent = config?.recordContent !== false;
     const maxSteps = options?.maxSteps ?? DEFAULT_MAX_STEPS;

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -235,7 +235,7 @@ export async function traceLLMCall(
   }
 
   return tracer.startActiveSpan(
-    `gen_ai.${effectiveInput.provider}.${effectiveInput.model}`,
+    `chat ${effectiveInput.model}`,
     async (span) => {
       const start = performance.now();
       setBaseAttributes(span, effectiveInput);


### PR DESCRIPTION
## Summary

- `traceLLMCall`: span name `gen_ai.{provider}.{model}` → `chat {model}` (e.g. `chat gpt-4o`)
- `traceAgentQuery`: span name `agent.query` → `invoke_agent`
- `traceAgentStep` with `type: "act"` + `toolName`: span name `agent.step.act` → `execute_tool {toolName}`
- `traceAgentStep` other types: span name `agent.step.{type}` → `gen_ai.agent.step.{type}`
- Add span name assertions to `spans.test.ts` and `agent.test.ts`

## Breaking change

Span names have changed. Any Jaeger filters, dashboard queries, or user code matching on span names must be updated.

| Before | After |
|--------|-------|
| `gen_ai.openai.gpt-4o` | `chat gpt-4o` |
| `gen_ai.anthropic.claude-sonnet-4-20250514` | `chat claude-sonnet-4-20250514` |
| `agent.query` | `invoke_agent` |
| `agent.step.act` (with tool) | `execute_tool {toolName}` |
| `agent.step.think` | `gen_ai.agent.step.think` |

## Why

OTel GenAI semantic conventions define span name format as `{operation} {model/agent/tool}`. The old `gen_ai.{provider}.{model}` format is not spec-compliant and breaks interop with tools like Arize Phoenix, SigNoz, and Datadog that expect the standard format.

Part of #128 decomposition. Next: #167 (add `gen_ai.agent.name`/`gen_ai.agent.id` to `traceAgentQuery` API).

## Test plan

- [x] All 240 tests pass
- [ ] Full stack run: `npx toad-eye up` + `npm run demo` — verify new span names appear in Jaeger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)