### PR TITLE
feat(semconv): add gen_ai.agent.name/id and gen_ai.tool.type (#167)

### DIFF
--- a/packages/instrumentation/src/__tests__/agent.test.ts
+++ b/packages/instrumentation/src/__tests__/agent.test.ts
@@ -86,14 +86,40 @@ describe("traceAgentStep", () => {
     expect(mockSpan.end).toHaveBeenCalled();
   });
 
-  it("includes toolName for act steps", () => {
+  it("emits both gen_ai.tool.name and gen_ai.agent.tool.name for act steps", () => {
     traceAgentStep({ type: "act", stepNumber: 2, toolName: "web-search" });
 
     expect(mockSpan.setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
+        "gen_ai.tool.name": "web-search",
         "gen_ai.agent.tool.name": "web-search",
       }),
     );
+  });
+
+  it("records gen_ai.tool.type when provided", () => {
+    traceAgentStep({
+      type: "act",
+      stepNumber: 2,
+      toolName: "search",
+      toolType: "function",
+    });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.tool.type": "function",
+      }),
+    );
+  });
+
+  it("omits gen_ai.tool.type when not provided", () => {
+    traceAgentStep({ type: "act", stepNumber: 2, toolName: "search" });
+
+    const attrs = mockSpan.setAttributes.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(attrs).not.toHaveProperty("gen_ai.tool.type");
   });
 
   it("records tool usage metric for act steps", () => {
@@ -142,8 +168,47 @@ describe("traceAgentQuery", () => {
     lastActiveSpanName = "";
   });
 
-  it("uses invoke_agent span name", async () => {
+  it("uses invoke_agent span name for string form", async () => {
     await traceAgentQuery("test query", async () => "result");
+
+    expect(lastActiveSpanName).toBe("invoke_agent");
+  });
+
+  it("uses invoke_agent {agentName} span name when agentName provided", async () => {
+    await traceAgentQuery(
+      { query: "test", agentName: "space-monitor" },
+      async () => "result",
+    );
+
+    expect(lastActiveSpanName).toBe("invoke_agent space-monitor");
+  });
+
+  it("records gen_ai.agent.name attribute when agentName provided", async () => {
+    await traceAgentQuery(
+      { query: "test", agentName: "space-monitor" },
+      async () => "result",
+    );
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.agent.name",
+      "space-monitor",
+    );
+  });
+
+  it("records gen_ai.agent.id attribute when agentId provided", async () => {
+    await traceAgentQuery(
+      { query: "test", agentName: "space-monitor", agentId: "agent-001" },
+      async () => "result",
+    );
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.agent.id",
+      "agent-001",
+    );
+  });
+
+  it("accepts object form without agentName (defaults to invoke_agent span name)", async () => {
+    await traceAgentQuery({ query: "test" }, async () => "result");
 
     expect(lastActiveSpanName).toBe("invoke_agent");
   });

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -1,5 +1,9 @@
 import { trace, SpanStatusCode } from "@opentelemetry/api";
-import type { AgentStepInput, AgentQueryOptions } from "./types/index.js";
+import type {
+  AgentStepInput,
+  AgentQueryOptions,
+  AgentQueryInput,
+} from "./types/index.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
 import { recordAgentSteps, recordAgentToolUsage } from "./core/metrics.js";
 import { getConfig } from "./core/tracer.js";
@@ -26,7 +30,12 @@ function traceAgentStep(input: AgentStepInput) {
     [GEN_AI_ATTRS.AGENT_STEP_TYPE]: input.type,
     [GEN_AI_ATTRS.AGENT_STEP_NUMBER]: input.stepNumber,
     ...(input.toolName !== undefined && {
+      // Emit both old (deprecated) and new spec-compliant attribute
       [GEN_AI_ATTRS.AGENT_TOOL_NAME]: input.toolName,
+      [GEN_AI_ATTRS.TOOL_NAME]: input.toolName,
+    }),
+    ...(input.toolType !== undefined && {
+      [GEN_AI_ATTRS.TOOL_TYPE]: input.toolType,
     }),
     ...(recordContent &&
       input.content !== undefined && {
@@ -52,6 +61,9 @@ function traceAgentStep(input: AgentStepInput) {
 /**
  * Wrap an entire agent query in a parent span with ReAct tracing.
  *
+ * Accepts either a string query (backward-compatible) or an object with
+ * agent metadata per OTel GenAI spec (agentName, agentId).
+ *
  * Supports multi-agent via nesting — child traceAgentQuery calls
  * automatically become child spans in Jaeger.
  *
@@ -60,13 +72,22 @@ function traceAgentStep(input: AgentStepInput) {
  *
  * @example
  * ```ts
+ * // Simple form (backward-compatible)
+ * await traceAgentQuery('Is anything dangerous?', async (step) => { ... });
+ *
+ * // Object form with agent metadata (OTel GenAI spec)
+ * await traceAgentQuery(
+ *   { query: 'Is anything dangerous?', agentName: 'space-monitor', agentId: 'agent-001' },
+ *   async (step) => { ... }
+ * );
+ *
  * // Multi-agent: orchestrator delegates to specialist
- * await traceAgentQuery('orchestrator', async (step) => {
+ * await traceAgentQuery({ query: 'Analyze data', agentName: 'orchestrator' }, async (step) => {
  *   step({ type: 'think', stepNumber: 1, content: 'Need domain expert' });
  *   step({ type: 'handoff', stepNumber: 2, toAgent: 'specialist', handoffReason: 'domain expertise' });
  *
- *   const result = await traceAgentQuery('specialist', async (step) => {
- *     step({ type: 'act', stepNumber: 1, toolName: 'analyze' });
+ *   const result = await traceAgentQuery({ query: 'Analyze', agentName: 'specialist' }, async (step) => {
+ *     step({ type: 'act', stepNumber: 1, toolName: 'analyze', toolType: 'function' });
  *     step({ type: 'answer', stepNumber: 2, content: 'analysis complete' });
  *     return { answer: 'done' };
  *   });
@@ -74,17 +95,33 @@ function traceAgentStep(input: AgentStepInput) {
  * ```
  */
 export async function traceAgentQuery<T>(
-  query: string,
+  queryOrInput: string | AgentQueryInput,
   fn: (step: (input: AgentStepInput) => void) => Promise<T>,
   options?: AgentQueryOptions,
 ): Promise<T> {
-  return tracer.startActiveSpan(`invoke_agent`, async (span) => {
+  const resolved =
+    typeof queryOrInput === "string"
+      ? { query: queryOrInput, agentName: undefined, agentId: undefined }
+      : queryOrInput;
+
+  const spanName = resolved.agentName
+    ? `invoke_agent ${resolved.agentName}`
+    : `invoke_agent`;
+
+  return tracer.startActiveSpan(spanName, async (span) => {
     const config = getConfig();
     const recordContent = config?.recordContent !== false;
     const maxSteps = options?.maxSteps ?? DEFAULT_MAX_STEPS;
 
+    // OTel GenAI agent attributes
+    if (resolved.agentName !== undefined) {
+      span.setAttribute(GEN_AI_ATTRS.AGENT_NAME, resolved.agentName);
+    }
+    if (resolved.agentId !== undefined) {
+      span.setAttribute(GEN_AI_ATTRS.AGENT_ID, resolved.agentId);
+    }
     if (recordContent) {
-      span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, query);
+      span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, resolved.query);
     }
 
     let stepCount = 0;

--- a/packages/instrumentation/src/types/attributes.ts
+++ b/packages/instrumentation/src/types/attributes.ts
@@ -17,9 +17,16 @@ export const GEN_AI_ATTRS = {
   FINISH_REASONS: "gen_ai.response.finish_reasons",
   ERROR: "error.type",
 
-  // Agent step attributes
+  // OTel GenAI agent attributes
+  AGENT_NAME: "gen_ai.agent.name",
+  AGENT_ID: "gen_ai.agent.id",
+  TOOL_NAME: "gen_ai.tool.name",
+  TOOL_TYPE: "gen_ai.tool.type",
+
+  // Agent step attributes (toad-eye ReAct extensions, not in OTel spec)
   AGENT_STEP_TYPE: "gen_ai.agent.step.type",
   AGENT_STEP_NUMBER: "gen_ai.agent.step.number",
+  /** @deprecated Use TOOL_NAME instead. Will be removed in v3.0. */
   AGENT_TOOL_NAME: "gen_ai.agent.tool.name",
   AGENT_STEP_CONTENT: "gen_ai.agent.step.content",
   AGENT_HANDOFF_TO: "gen_ai.agent.handoff.to",

--- a/packages/instrumentation/src/types/index.ts
+++ b/packages/instrumentation/src/types/index.ts
@@ -22,6 +22,7 @@ export type {
   AgentStepType,
   AgentStepInput,
   AgentQueryOptions,
+  AgentQueryInput,
   GuardMode,
   GuardResult,
 } from "./spans.js";

--- a/packages/instrumentation/src/types/spans.ts
+++ b/packages/instrumentation/src/types/spans.ts
@@ -12,6 +12,13 @@ export interface AgentStepInput {
   readonly stepNumber: number;
   readonly content?: string | undefined;
   readonly toolName?: string | undefined;
+  /** Tool type per OTel GenAI spec: function, extension, retrieval, builtin */
+  readonly toolType?:
+    | "function"
+    | "extension"
+    | "retrieval"
+    | "builtin"
+    | undefined;
   /** Target agent name for handoff steps */
   readonly toAgent?: string | undefined;
   /** Reason for handoff */
@@ -22,6 +29,15 @@ export interface AgentStepInput {
 export interface AgentQueryOptions {
   /** Max steps before recording a warning. Default: 25 */
   readonly maxSteps?: number | undefined;
+}
+
+/** Input for traceAgentQuery — object form with agent metadata */
+export interface AgentQueryInput {
+  readonly query: string;
+  /** Agent name — maps to gen_ai.agent.name and span name invoke_agent {agentName} */
+  readonly agentName?: string | undefined;
+  /** Agent identifier — maps to gen_ai.agent.id */
+  readonly agentId?: string | undefined;
 }
 
 /** Guard execution mode */


### PR DESCRIPTION
## Summary

### `traceAgentQuery` — object form + agent metadata

```ts
// String form — backward-compatible, no changes needed
await traceAgentQuery('Is anything dangerous?', async (step) => { ... });

// Object form — new, with OTel GenAI agent attributes
await traceAgentQuery(
  { query: 'Is anything dangerous?', agentName: 'space-monitor', agentId: 'agent-001' },
  async (step) => { ... }
);
```

- Span name: `invoke_agent space-monitor` (when agentName provided)
- Records `gen_ai.agent.name` and `gen_ai.agent.id` as span attributes

### `traceAgentStep` — tool type + dual tool name

```ts
step({
  type: 'act',
  stepNumber: 2,
  toolName: 'search',
  toolType: 'function',  // NEW — maps to gen_ai.tool.type
});
```

- Records `gen_ai.tool.name` (OTel spec) alongside `gen_ai.agent.tool.name` (deprecated, kept for backward compat)
- `gen_ai.tool.type` values: `function | extension | retrieval | builtin`

### New types

- `AgentQueryInput` — object input for `traceAgentQuery`
- `AgentStepInput.toolType` — optional tool type field

### New attributes in `GEN_AI_ATTRS`

| Key | Value |
|-----|-------|
| `AGENT_NAME` | `gen_ai.agent.name` |
| `AGENT_ID` | `gen_ai.agent.id` |
| `TOOL_NAME` | `gen_ai.tool.name` |
| `TOOL_TYPE` | `gen_ai.tool.type` |
| `AGENT_TOOL_NAME` | `gen_ai.agent.tool.name` — **@deprecated**, use `TOOL_NAME` |

## Test plan

- [x] 246 tests pass
- [x] Backward compat: string form still works
- [x] Span name assertions for both string and object forms

Part of #128 decomposition. Next: #168 (migrate custom agent attrs to `gen_ai.toad_eye.*` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)