### PR TITLE
feat(semconv): migrate ReAct attrs to gen_ai.toad_eye.agent.* prefix (#168)

### DIFF
--- a/packages/instrumentation/src/__tests__/agent.test.ts
+++ b/packages/instrumentation/src/__tests__/agent.test.ts
@@ -74,7 +74,19 @@ describe("traceAgentStep", () => {
     expect(lastSpanName).toBe("gen_ai.agent.step.act");
   });
 
-  it("creates a span with step type and number", () => {
+  it("creates a span with step type and number (toad_eye namespace)", () => {
+    traceAgentStep({ type: "think", stepNumber: 1 });
+
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.toad_eye.agent.step.type": "think",
+        "gen_ai.toad_eye.agent.step.number": 1,
+      }),
+    );
+    expect(mockSpan.end).toHaveBeenCalled();
+  });
+
+  it("emits deprecated gen_ai.agent.step.* aliases alongside new toad_eye attrs", () => {
     traceAgentStep({ type: "think", stepNumber: 1 });
 
     expect(mockSpan.setAttributes).toHaveBeenCalledWith(
@@ -83,7 +95,6 @@ describe("traceAgentStep", () => {
         "gen_ai.agent.step.number": 1,
       }),
     );
-    expect(mockSpan.end).toHaveBeenCalled();
   });
 
   it("emits both gen_ai.tool.name and gen_ai.agent.tool.name for act steps", () => {
@@ -134,11 +145,12 @@ describe("traceAgentStep", () => {
     expect(mockRecordAgentToolUsage).not.toHaveBeenCalled();
   });
 
-  it("includes content when recordContent is enabled", () => {
+  it("includes content in toad_eye namespace when recordContent is enabled", () => {
     traceAgentStep({ type: "think", stepNumber: 1, content: "reasoning here" });
 
     expect(mockSpan.setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
+        "gen_ai.toad_eye.agent.step.content": "reasoning here",
         "gen_ai.agent.step.content": "reasoning here",
       }),
     );
@@ -156,6 +168,7 @@ describe("traceAgentStep", () => {
       string,
       unknown
     >;
+    expect(attrs).not.toHaveProperty("gen_ai.toad_eye.agent.step.content");
     expect(attrs).not.toHaveProperty("gen_ai.agent.step.content");
   });
 });
@@ -281,7 +294,7 @@ describe("handoff steps (#133)", () => {
     mockConfig = {};
   });
 
-  it("records handoff attributes on step span", () => {
+  it("records handoff attributes in toad_eye namespace + deprecated aliases", () => {
     traceAgentStep({
       type: "handoff",
       stepNumber: 3,
@@ -291,6 +304,11 @@ describe("handoff steps (#133)", () => {
 
     expect(mockSpan.setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
+        // New toad_eye namespace (canonical)
+        "gen_ai.toad_eye.agent.step.type": "handoff",
+        "gen_ai.toad_eye.agent.handoff.to": "specialist",
+        "gen_ai.toad_eye.agent.handoff.reason": "needs domain expertise",
+        // Deprecated aliases (backward compat)
         "gen_ai.agent.step.type": "handoff",
         "gen_ai.agent.handoff.to": "specialist",
         "gen_ai.agent.handoff.reason": "needs domain expertise",
@@ -320,6 +338,10 @@ describe("loop detection (#133)", () => {
     });
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.toad_eye.agent.loop_count",
+      2,
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       "gen_ai.agent.loop_count",
       2,
     );
@@ -333,6 +355,10 @@ describe("loop detection (#133)", () => {
       step({ type: "answer", stepNumber: 4 });
     });
 
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "gen_ai.toad_eye.agent.loop_count",
+      0,
+    );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       "gen_ai.agent.loop_count",
       0,

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -27,25 +27,36 @@ function traceAgentStep(input: AgentStepInput) {
   const recordContent = config?.recordContent !== false;
 
   span.setAttributes({
+    // Emit new toad_eye namespace (canonical)
+    [GEN_AI_ATTRS.TOAD_AGENT_STEP_TYPE]: input.type,
+    [GEN_AI_ATTRS.TOAD_AGENT_STEP_NUMBER]: input.stepNumber,
+    // Emit deprecated aliases for backward compat (removed in v3.0)
     [GEN_AI_ATTRS.AGENT_STEP_TYPE]: input.type,
     [GEN_AI_ATTRS.AGENT_STEP_NUMBER]: input.stepNumber,
     ...(input.toolName !== undefined && {
-      // Emit both old (deprecated) and new spec-compliant attribute
-      [GEN_AI_ATTRS.AGENT_TOOL_NAME]: input.toolName,
+      // OTel spec attribute (gen_ai.tool.name)
       [GEN_AI_ATTRS.TOOL_NAME]: input.toolName,
+      // Deprecated alias (gen_ai.agent.tool.name) — removed in v3.0
+      [GEN_AI_ATTRS.AGENT_TOOL_NAME]: input.toolName,
     }),
     ...(input.toolType !== undefined && {
       [GEN_AI_ATTRS.TOOL_TYPE]: input.toolType,
     }),
     ...(recordContent &&
       input.content !== undefined && {
+        [GEN_AI_ATTRS.TOAD_AGENT_STEP_CONTENT]: input.content,
+        // Deprecated alias — removed in v3.0
         [GEN_AI_ATTRS.AGENT_STEP_CONTENT]: input.content,
       }),
-    // Handoff attributes
+    // Handoff attributes — new toad_eye namespace
     ...(input.toAgent !== undefined && {
+      [GEN_AI_ATTRS.TOAD_AGENT_HANDOFF_TO]: input.toAgent,
+      // Deprecated alias — removed in v3.0
       [GEN_AI_ATTRS.AGENT_HANDOFF_TO]: input.toAgent,
     }),
     ...(input.handoffReason !== undefined && {
+      [GEN_AI_ATTRS.TOAD_AGENT_HANDOFF_REASON]: input.handoffReason,
+      // Deprecated alias — removed in v3.0
       [GEN_AI_ATTRS.AGENT_HANDOFF_REASON]: input.handoffReason,
     }),
   });
@@ -121,6 +132,8 @@ export async function traceAgentQuery<T>(
       span.setAttribute(GEN_AI_ATTRS.AGENT_ID, resolved.agentId);
     }
     if (recordContent) {
+      span.setAttribute(GEN_AI_ATTRS.TOAD_AGENT_STEP_CONTENT, resolved.query);
+      // Deprecated alias — removed in v3.0
       span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, resolved.query);
     }
 
@@ -154,11 +167,13 @@ export async function traceAgentQuery<T>(
         traceAgentStep(input);
       });
 
+      span.setAttribute(GEN_AI_ATTRS.TOAD_AGENT_LOOP_COUNT, loopCount);
       span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
       span.setStatus({ code: SpanStatusCode.OK });
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      span.setAttribute(GEN_AI_ATTRS.TOAD_AGENT_LOOP_COUNT, loopCount);
       span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
       span.setStatus({ code: SpanStatusCode.ERROR, message });
       throw error;

--- a/packages/instrumentation/src/types/attributes.ts
+++ b/packages/instrumentation/src/types/attributes.ts
@@ -23,14 +23,28 @@ export const GEN_AI_ATTRS = {
   TOOL_NAME: "gen_ai.tool.name",
   TOOL_TYPE: "gen_ai.tool.type",
 
-  // Agent step attributes (toad-eye ReAct extensions, not in OTel spec)
+  // toad-eye ReAct extensions (gen_ai.toad_eye.agent.* — correct namespace)
+  TOAD_AGENT_STEP_TYPE: "gen_ai.toad_eye.agent.step.type",
+  TOAD_AGENT_STEP_NUMBER: "gen_ai.toad_eye.agent.step.number",
+  TOAD_AGENT_STEP_CONTENT: "gen_ai.toad_eye.agent.step.content",
+  TOAD_AGENT_HANDOFF_TO: "gen_ai.toad_eye.agent.handoff.to",
+  TOAD_AGENT_HANDOFF_REASON: "gen_ai.toad_eye.agent.handoff.reason",
+  TOAD_AGENT_LOOP_COUNT: "gen_ai.toad_eye.agent.loop_count",
+
+  // Agent step attributes — @deprecated aliases (will be removed in v3.0)
+  /** @deprecated Use TOAD_AGENT_STEP_TYPE instead. Will be removed in v3.0. */
   AGENT_STEP_TYPE: "gen_ai.agent.step.type",
+  /** @deprecated Use TOAD_AGENT_STEP_NUMBER instead. Will be removed in v3.0. */
   AGENT_STEP_NUMBER: "gen_ai.agent.step.number",
   /** @deprecated Use TOOL_NAME instead. Will be removed in v3.0. */
   AGENT_TOOL_NAME: "gen_ai.agent.tool.name",
+  /** @deprecated Use TOAD_AGENT_STEP_CONTENT instead. Will be removed in v3.0. */
   AGENT_STEP_CONTENT: "gen_ai.agent.step.content",
+  /** @deprecated Use TOAD_AGENT_HANDOFF_TO instead. Will be removed in v3.0. */
   AGENT_HANDOFF_TO: "gen_ai.agent.handoff.to",
+  /** @deprecated Use TOAD_AGENT_HANDOFF_REASON instead. Will be removed in v3.0. */
   AGENT_HANDOFF_REASON: "gen_ai.agent.handoff.reason",
+  /** @deprecated Use TOAD_AGENT_LOOP_COUNT instead. Will be removed in v3.0. */
   AGENT_LOOP_COUNT: "gen_ai.agent.loop_count",
 
   // Guard (shadow mode) attributes


### PR DESCRIPTION
## Summary

ReAct-specific agent attributes (not in OTel spec) are moved to the `gen_ai.toad_eye.agent.*` namespace. Old `gen_ai.agent.*` names continue to be emitted as deprecated aliases — removed in v3.0.

## Attribute migration table

| Old (deprecated) | New (canonical) |
|------------------|-----------------|
| `gen_ai.agent.step.type` | `gen_ai.toad_eye.agent.step.type` |
| `gen_ai.agent.step.number` | `gen_ai.toad_eye.agent.step.number` |
| `gen_ai.agent.step.content` | `gen_ai.toad_eye.agent.step.content` |
| `gen_ai.agent.handoff.to` | `gen_ai.toad_eye.agent.handoff.to` |
| `gen_ai.agent.handoff.reason` | `gen_ai.toad_eye.agent.handoff.reason` |
| `gen_ai.agent.loop_count` | `gen_ai.toad_eye.agent.loop_count` |
| `gen_ai.agent.tool.name` | `gen_ai.tool.name` (OTel spec) |

## Why `gen_ai.toad_eye.*`

These attributes are toad-eye innovations (ReAct step tracking, handoff, loop detection) with no equivalent in the OTel GenAI spec. Using `gen_ai.toad_eye.agent.*` signals clearly: "this is toad-eye's extension, not a standard attribute." Standard attributes remain under `gen_ai.*` (e.g. `gen_ai.agent.name`, `gen_ai.tool.name`).

## v2.4 strategy: emit both

In v2.4, both old and new attribute names are emitted simultaneously. Users can migrate Jaeger filters / Grafana queries at their own pace. In v3.0, the deprecated aliases are removed.

## `GEN_AI_ATTRS` constants

New keys added: `TOAD_AGENT_STEP_TYPE`, `TOAD_AGENT_STEP_NUMBER`, `TOAD_AGENT_STEP_CONTENT`, `TOAD_AGENT_HANDOFF_TO`, `TOAD_AGENT_HANDOFF_REASON`, `TOAD_AGENT_LOOP_COUNT`.

Old keys `AGENT_STEP_TYPE` etc. marked `@deprecated` with JSDoc pointing to the new names.

## Test plan

- [x] 247 tests pass
- [x] Tests verify both new `toad_eye` attrs and deprecated aliases are emitted

Part of #128 decomposition. Next: #169 (compatibility matrix + `OTEL_SEMCONV_STABILITY_OPT_IN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)