### PR TITLE
feat(semconv): compatibility matrix + OTEL_SEMCONV_STABILITY_OPT_IN (#169)

### DIFF
--- a/packages/instrumentation/COMPATIBILITY.md
+++ b/packages/instrumentation/COMPATIBILITY.md
@@ -1,0 +1,107 @@
+# toad-eye Compatibility Matrix
+
+Which observability backends work with toad-eye traces, metrics, and agent spans.
+
+**Last updated:** 2026-03-21 (toad-eye v2.4, OTel GenAI semconv — all experimental)
+
+---
+
+## Backend support
+
+| Backend             | Traces  | Metrics               | GenAI span viz                   | Agent spans          | Events                    | Notes                                                                                                                                 |
+| ------------------- | ------- | --------------------- | -------------------------------- | -------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Jaeger**          | Full    | N/A                   | Basic (shows spans + attributes) | Nested spans         | Span logs                 | No GenAI-specific UI. Good for trace exploration.                                                                                     |
+| **Grafana + Tempo** | Full    | Full (via Prometheus) | Basic (via Grafana)              | Nested spans         | Span logs                 | Primary recommended setup. 8 dashboards ship with toad-eye.                                                                           |
+| **Prometheus**      | N/A     | Full                  | N/A                              | N/A                  | N/A                       | Metrics only. Powers Grafana dashboards.                                                                                              |
+| **Arize Phoenix**   | Full    | Partial               | Full GenAI UI                    | Agent workflow viz   | Full                      | Built for GenAI. Expects OTel + OpenInference. See [OpenInference bridge (#123)](https://github.com/vola-trebla/toad-eye/issues/123). |
+| **SigNoz**          | Full    | Full                  | GenAI dashboards                 | Nested spans         | Full                      | Has pre-built Vercel AI SDK dashboard.                                                                                                |
+| **Datadog**         | Full    | Full                  | LLM Observability product        | Agent tracing        | Full                      | Proprietary mapping from OTel. Requires Datadog OTel Collector config.                                                                |
+| **Langfuse**        | Partial | N/A                   | Full GenAI UI                    | Session + trace view | Via LangfuseSpanProcessor | Expects specific attribute mapping (`ai.usage.promptTokens`).                                                                         |
+| **Honeycomb**       | Full    | Full                  | Basic                            | Nested spans         | Full                      | Good general OTel support, no GenAI-specific UI.                                                                                      |
+
+---
+
+## Attribute compatibility
+
+### Standard OTel GenAI attributes (all backends)
+
+These attributes are part of the OTel GenAI semantic conventions and indexed by all OTel-compatible backends:
+
+| Attribute                        | toad-eye constant             | Used for                 |
+| -------------------------------- | ----------------------------- | ------------------------ |
+| `gen_ai.operation.name`          | `GEN_AI_ATTRS.OPERATION`      | Operation type filtering |
+| `gen_ai.request.model`           | `GEN_AI_ATTRS.REQUEST_MODEL`  | Model filtering          |
+| `gen_ai.provider.name`           | `GEN_AI_ATTRS.PROVIDER`       | Provider filtering       |
+| `gen_ai.usage.input_tokens`      | `GEN_AI_ATTRS.INPUT_TOKENS`   | Token tracking           |
+| `gen_ai.usage.output_tokens`     | `GEN_AI_ATTRS.OUTPUT_TOKENS`  | Token tracking           |
+| `gen_ai.response.finish_reasons` | `GEN_AI_ATTRS.FINISH_REASONS` | Completion status        |
+| `error.type`                     | `GEN_AI_ATTRS.ERROR`          | Error filtering          |
+| `gen_ai.agent.name`              | `GEN_AI_ATTRS.AGENT_NAME`     | Agent identification     |
+| `gen_ai.agent.id`                | `GEN_AI_ATTRS.AGENT_ID`       | Agent identification     |
+| `gen_ai.tool.name`               | `GEN_AI_ATTRS.TOOL_NAME`      | Tool identification      |
+| `gen_ai.tool.type`               | `GEN_AI_ATTRS.TOOL_TYPE`      | Tool classification      |
+
+### toad-eye extension attributes
+
+These are toad-eye-specific and not part of the OTel spec. Backends store them as custom attributes — queryable but not auto-visualized:
+
+| Attribute                           | toad-eye constant                     | Purpose                     |
+| ----------------------------------- | ------------------------------------- | --------------------------- |
+| `gen_ai.toad_eye.cost`              | `GEN_AI_ATTRS.COST`                   | Cost in USD                 |
+| `gen_ai.toad_eye.prompt`            | `GEN_AI_ATTRS.PROMPT`                 | Prompt content (opt-in)     |
+| `gen_ai.toad_eye.completion`        | `GEN_AI_ATTRS.COMPLETION`             | Completion content (opt-in) |
+| `gen_ai.toad_eye.agent.step.type`   | `GEN_AI_ATTRS.TOAD_AGENT_STEP_TYPE`   | ReAct step type             |
+| `gen_ai.toad_eye.agent.step.number` | `GEN_AI_ATTRS.TOAD_AGENT_STEP_NUMBER` | Step sequence number        |
+| `gen_ai.toad_eye.agent.handoff.to`  | `GEN_AI_ATTRS.TOAD_AGENT_HANDOFF_TO`  | Handoff target agent        |
+| `gen_ai.toad_eye.agent.loop_count`  | `GEN_AI_ATTRS.TOAD_AGENT_LOOP_COUNT`  | ReAct loop iterations       |
+| `gen_ai.toad_eye.guard.*`           | `GEN_AI_ATTRS.GUARD_*`                | toad-guard integration      |
+
+---
+
+## Span naming convention
+
+toad-eye follows the OTel GenAI span naming spec:
+
+| Span type      | Name format                | Example                      |
+| -------------- | -------------------------- | ---------------------------- |
+| LLM call       | `chat {model}`             | `chat gpt-4o`                |
+| Agent query    | `invoke_agent {agentName}` | `invoke_agent space-monitor` |
+| Tool execution | `execute_tool {toolName}`  | `execute_tool web-search`    |
+| Agent step     | `gen_ai.agent.step.{type}` | `gen_ai.agent.step.think`    |
+
+---
+
+## OTEL_SEMCONV_STABILITY_OPT_IN
+
+toad-eye respects the standard OTel env var for controlling semconv attribute emission:
+
+```bash
+# Default: emit both new (gen_ai.toad_eye.*) and deprecated (gen_ai.agent.*) attributes
+# No env var needed
+
+# Latest experimental: emit only new canonical attributes (skip deprecated aliases)
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+```
+
+When `gen_ai_latest_experimental` is in the comma-separated list, deprecated attribute aliases (e.g. `gen_ai.agent.step.type`) are **not emitted**. Only the canonical `gen_ai.toad_eye.agent.*` and OTel standard `gen_ai.*` attributes are recorded.
+
+This env var is evaluated at span creation time, not at init.
+
+---
+
+## Recommended setup
+
+For most teams, the built-in stack is the fastest path:
+
+```bash
+npx toad-eye init   # scaffold docker-compose + dashboards
+npx toad-eye up     # start Jaeger + Prometheus + Grafana + OTel Collector
+```
+
+This gives you:
+
+- **Grafana** (localhost:3100) — 8 pre-built dashboards for LLM metrics
+- **Jaeger** (localhost:16686) — trace exploration with full span detail
+- **Prometheus** (localhost:9090) — raw metrics for custom queries
+
+For production, replace with your preferred backend (Datadog, SigNoz, etc.) by pointing `endpoint` in `initObservability()` to your OTel Collector.

--- a/packages/instrumentation/src/__tests__/agent.test.ts
+++ b/packages/instrumentation/src/__tests__/agent.test.ts
@@ -42,8 +42,10 @@ vi.mock("../core/metrics.js", () => ({
 }));
 
 let mockConfig: Record<string, unknown> = {};
+let mockEmitDeprecated = true;
 vi.mock("../core/tracer.js", () => ({
   getConfig: () => mockConfig,
+  shouldEmitDeprecatedAttrs: () => mockEmitDeprecated,
 }));
 
 const { traceAgentStep, traceAgentQuery } = await import("../agent.js");
@@ -52,6 +54,7 @@ describe("traceAgentStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig = {};
+    mockEmitDeprecated = true;
     lastSpanName = "";
     lastActiveSpanName = "";
   });
@@ -171,12 +174,29 @@ describe("traceAgentStep", () => {
     expect(attrs).not.toHaveProperty("gen_ai.toad_eye.agent.step.content");
     expect(attrs).not.toHaveProperty("gen_ai.agent.step.content");
   });
+
+  it("skips deprecated aliases when OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental", () => {
+    mockEmitDeprecated = false;
+    traceAgentStep({ type: "act", stepNumber: 2, toolName: "search" });
+
+    const attrs = mockSpan.setAttributes.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    // Canonical attrs present
+    expect(attrs).toHaveProperty("gen_ai.toad_eye.agent.step.type", "act");
+    expect(attrs).toHaveProperty("gen_ai.tool.name", "search");
+    // Deprecated aliases absent
+    expect(attrs).not.toHaveProperty("gen_ai.agent.step.type");
+    expect(attrs).not.toHaveProperty("gen_ai.agent.tool.name");
+  });
 });
 
 describe("traceAgentQuery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig = {};
+    mockEmitDeprecated = true;
     lastSpanName = "";
     lastActiveSpanName = "";
   });

--- a/packages/instrumentation/src/__tests__/tracer.test.ts
+++ b/packages/instrumentation/src/__tests__/tracer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 // Mock OTel SDK to avoid real initialization
 vi.mock("@opentelemetry/sdk-node", () => ({
@@ -49,7 +49,8 @@ const { OTLPTraceExporter } =
   await import("@opentelemetry/exporter-trace-otlp-http");
 const { OTLPMetricExporter } =
   await import("@opentelemetry/exporter-metrics-otlp-http");
-const { initObservability, shutdown } = await import("../core/tracer.js");
+const { initObservability, shutdown, shouldEmitDeprecatedAttrs } =
+  await import("../core/tracer.js");
 
 describe("initObservability — config validation", () => {
   it("throws on empty serviceName", () => {
@@ -175,5 +176,38 @@ describe("singleton lifecycle", () => {
 
     expect(resetMetrics).toHaveBeenCalled();
     expect(resetCustomPricing).toHaveBeenCalled();
+  });
+});
+
+describe("shouldEmitDeprecatedAttrs", () => {
+  const originalEnv = process.env["OTEL_SEMCONV_STABILITY_OPT_IN"];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["OTEL_SEMCONV_STABILITY_OPT_IN"];
+    } else {
+      process.env["OTEL_SEMCONV_STABILITY_OPT_IN"] = originalEnv;
+    }
+  });
+
+  it("returns true by default (no env var)", () => {
+    delete process.env["OTEL_SEMCONV_STABILITY_OPT_IN"];
+    expect(shouldEmitDeprecatedAttrs()).toBe(true);
+  });
+
+  it("returns false when set to gen_ai_latest_experimental", () => {
+    process.env["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental";
+    expect(shouldEmitDeprecatedAttrs()).toBe(false);
+  });
+
+  it("returns false when gen_ai_latest_experimental is in comma-separated list", () => {
+    process.env["OTEL_SEMCONV_STABILITY_OPT_IN"] =
+      "http,gen_ai_latest_experimental,database";
+    expect(shouldEmitDeprecatedAttrs()).toBe(false);
+  });
+
+  it("returns true for unrelated opt-in values", () => {
+    process.env["OTEL_SEMCONV_STABILITY_OPT_IN"] = "http,database";
+    expect(shouldEmitDeprecatedAttrs()).toBe(true);
   });
 });

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -6,7 +6,7 @@ import type {
 } from "./types/index.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
 import { recordAgentSteps, recordAgentToolUsage } from "./core/metrics.js";
-import { getConfig } from "./core/tracer.js";
+import { getConfig, shouldEmitDeprecatedAttrs } from "./core/tracer.js";
 
 const tracer = trace.getTracer(INSTRUMENTATION_NAME);
 
@@ -25,19 +25,24 @@ function traceAgentStep(input: AgentStepInput) {
 
   const config = getConfig();
   const recordContent = config?.recordContent !== false;
+  const emitDeprecated = shouldEmitDeprecatedAttrs();
 
   span.setAttributes({
-    // Emit new toad_eye namespace (canonical)
+    // Canonical toad_eye namespace
     [GEN_AI_ATTRS.TOAD_AGENT_STEP_TYPE]: input.type,
     [GEN_AI_ATTRS.TOAD_AGENT_STEP_NUMBER]: input.stepNumber,
-    // Emit deprecated aliases for backward compat (removed in v3.0)
-    [GEN_AI_ATTRS.AGENT_STEP_TYPE]: input.type,
-    [GEN_AI_ATTRS.AGENT_STEP_NUMBER]: input.stepNumber,
+    // Deprecated aliases (skipped when OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental)
+    ...(emitDeprecated && {
+      [GEN_AI_ATTRS.AGENT_STEP_TYPE]: input.type,
+      [GEN_AI_ATTRS.AGENT_STEP_NUMBER]: input.stepNumber,
+    }),
     ...(input.toolName !== undefined && {
-      // OTel spec attribute (gen_ai.tool.name)
+      // OTel spec attribute
       [GEN_AI_ATTRS.TOOL_NAME]: input.toolName,
-      // Deprecated alias (gen_ai.agent.tool.name) — removed in v3.0
-      [GEN_AI_ATTRS.AGENT_TOOL_NAME]: input.toolName,
+      // Deprecated alias
+      ...(emitDeprecated && {
+        [GEN_AI_ATTRS.AGENT_TOOL_NAME]: input.toolName,
+      }),
     }),
     ...(input.toolType !== undefined && {
       [GEN_AI_ATTRS.TOOL_TYPE]: input.toolType,
@@ -45,19 +50,22 @@ function traceAgentStep(input: AgentStepInput) {
     ...(recordContent &&
       input.content !== undefined && {
         [GEN_AI_ATTRS.TOAD_AGENT_STEP_CONTENT]: input.content,
-        // Deprecated alias — removed in v3.0
-        [GEN_AI_ATTRS.AGENT_STEP_CONTENT]: input.content,
+        ...(emitDeprecated && {
+          [GEN_AI_ATTRS.AGENT_STEP_CONTENT]: input.content,
+        }),
       }),
-    // Handoff attributes — new toad_eye namespace
+    // Handoff attributes
     ...(input.toAgent !== undefined && {
       [GEN_AI_ATTRS.TOAD_AGENT_HANDOFF_TO]: input.toAgent,
-      // Deprecated alias — removed in v3.0
-      [GEN_AI_ATTRS.AGENT_HANDOFF_TO]: input.toAgent,
+      ...(emitDeprecated && {
+        [GEN_AI_ATTRS.AGENT_HANDOFF_TO]: input.toAgent,
+      }),
     }),
     ...(input.handoffReason !== undefined && {
       [GEN_AI_ATTRS.TOAD_AGENT_HANDOFF_REASON]: input.handoffReason,
-      // Deprecated alias — removed in v3.0
-      [GEN_AI_ATTRS.AGENT_HANDOFF_REASON]: input.handoffReason,
+      ...(emitDeprecated && {
+        [GEN_AI_ATTRS.AGENT_HANDOFF_REASON]: input.handoffReason,
+      }),
     }),
   });
 
@@ -122,6 +130,7 @@ export async function traceAgentQuery<T>(
   return tracer.startActiveSpan(spanName, async (span) => {
     const config = getConfig();
     const recordContent = config?.recordContent !== false;
+    const emitDeprecated = shouldEmitDeprecatedAttrs();
     const maxSteps = options?.maxSteps ?? DEFAULT_MAX_STEPS;
 
     // OTel GenAI agent attributes
@@ -133,8 +142,9 @@ export async function traceAgentQuery<T>(
     }
     if (recordContent) {
       span.setAttribute(GEN_AI_ATTRS.TOAD_AGENT_STEP_CONTENT, resolved.query);
-      // Deprecated alias — removed in v3.0
-      span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, resolved.query);
+      if (emitDeprecated) {
+        span.setAttribute(GEN_AI_ATTRS.AGENT_STEP_CONTENT, resolved.query);
+      }
     }
 
     let stepCount = 0;
@@ -168,13 +178,17 @@ export async function traceAgentQuery<T>(
       });
 
       span.setAttribute(GEN_AI_ATTRS.TOAD_AGENT_LOOP_COUNT, loopCount);
-      span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
+      if (emitDeprecated) {
+        span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
+      }
       span.setStatus({ code: SpanStatusCode.OK });
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       span.setAttribute(GEN_AI_ATTRS.TOAD_AGENT_LOOP_COUNT, loopCount);
-      span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
+      if (emitDeprecated) {
+        span.setAttribute(GEN_AI_ATTRS.AGENT_LOOP_COUNT, loopCount);
+      }
       span.setStatus({ code: SpanStatusCode.ERROR, message });
       throw error;
     } finally {

--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -27,6 +27,16 @@ export function getConfig() {
   return currentConfig;
 }
 
+/**
+ * Check if deprecated semconv aliases should be emitted.
+ * When OTEL_SEMCONV_STABILITY_OPT_IN includes "gen_ai_latest_experimental",
+ * only new (canonical) attributes are emitted — deprecated aliases are skipped.
+ */
+export function shouldEmitDeprecatedAttrs(): boolean {
+  const optIn = process.env["OTEL_SEMCONV_STABILITY_OPT_IN"] ?? "";
+  return !optIn.split(",").includes("gen_ai_latest_experimental");
+}
+
 export function getBudgetTracker() {
   return budgetTracker;
 }


### PR DESCRIPTION
## Summary

### `OTEL_SEMCONV_STABILITY_OPT_IN` env var

```bash
# Default: emit both new + deprecated attrs (backward compat, no env var needed)

# Latest experimental: skip deprecated aliases
export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
```

When `gen_ai_latest_experimental` is in the comma-separated list:
- `gen_ai.agent.step.type`, `gen_ai.agent.tool.name`, `gen_ai.agent.loop_count` etc. are **not emitted**
- Only `gen_ai.toad_eye.agent.*` (canonical) and `gen_ai.*` (OTel spec) attributes are recorded

New export: `shouldEmitDeprecatedAttrs()` in `core/tracer.ts`.

### Compatibility matrix doc

`packages/instrumentation/COMPATIBILITY.md` — documents:
- 8 backends (Jaeger, Grafana+Tempo, Prometheus, Arize Phoenix, SigNoz, Datadog, Langfuse, Honeycomb)
- Which OTel GenAI attributes each backend indexes
- toad-eye span naming convention
- How to use `OTEL_SEMCONV_STABILITY_OPT_IN`

## Test plan

- [x] 252 tests pass
- [x] 4 new tests for `shouldEmitDeprecatedAttrs()` (default, opt-in, comma-separated, unrelated values)
- [x] Agent test: deprecated attrs skipped when opt-in active

Final issue in #128 decomposition. Closes #169 and completes the full semconv alignment (#166-#169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)