### PR TITLE
fix(semconv): streaming span name + tool usage metric alignment

### DIFF
--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -177,7 +177,7 @@ export function recordAgentSteps(stepCount: number) {
 
 export function recordAgentToolUsage(toolName: string) {
   agentToolUsage.add(1, {
-    [GEN_AI_ATTRS.AGENT_TOOL_NAME]: toolName,
+    [GEN_AI_ATTRS.TOOL_NAME]: toolName,
   });
 }
 

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -140,9 +140,7 @@ function createStreamingHandler(
       }
     }
 
-    const span: Span = tracer.startSpan(
-      `gen_ai.${effectiveProvider}.${effectiveModel}`,
-    );
+    const span: Span = tracer.startSpan(`chat ${effectiveModel}`);
     const ctx = trace.setSpan(context.active(), span);
     const sessionId = config?.sessionExtractor?.() ?? config?.sessionId;
 


### PR DESCRIPTION
## Summary

- Streaming handler span name: `gen_ai.{provider}.{model}` → `chat {model}` to match non-streaming path and OTel GenAI spec
- Tool usage metric: use canonical `gen_ai.tool.name` instead of deprecated `gen_ai.agent.tool.name`

Found during post-merge review of #128 semconv changes.

## Files changed

- `instrumentations/create.ts:144` — streaming span name
- `core/metrics.ts:180` — tool usage metric attribute key

## Test plan

- [x] Build passes
- [x] 252 tests pass
- [x] Streaming spans now use same naming as non-streaming (`chat {model}`)
- [x] Tool usage metric uses canonical OTel attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)