### PR TITLE
fix: auto-inject stream_options for OpenAI streaming token counts

### DIFF
--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -113,6 +113,15 @@ function createStreamingHandler(
     body: unknown,
     rest: unknown[],
   ) {
+    // OpenAI does not send usage in streaming chunks by default.
+    // Auto-inject stream_options to get token counts in the final chunk.
+    if (providerName === "openai") {
+      const b = body as Record<string, unknown>;
+      if (!b["stream_options"]) {
+        b["stream_options"] = { include_usage: true };
+      }
+    }
+
     // Pass thisArg so extractRequest can access instance properties (e.g., Gemini model name)
     const req = patch.extractRequest(body, thisArg);
     const start = performance.now();


### PR DESCRIPTION
## Summary

- Auto-inject `stream_options: { include_usage: true }` for OpenAI streaming calls
- Without this, token counts are 0 for every streaming request → cost tracking broken

## Fix

9 lines in `create.ts` — check if provider is `openai` and `stream_options` not set, inject before calling the original method.

## Test plan

- [x] Build passes
- [x] 252 tests pass
- [x] Manual: OpenAI streaming call → verify inputTokens > 0 in Jaeger

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)