### PR TITLE
feat: tool usage analytics — duration + success/error (#38)

### DIFF
--- a/packages/instrumentation/src/__tests__/agent.test.ts
+++ b/packages/instrumentation/src/__tests__/agent.test.ts
@@ -139,7 +139,10 @@ describe("traceAgentStep", () => {
   it("records tool usage metric for act steps", () => {
     traceAgentStep({ type: "act", stepNumber: 2, toolName: "web-search" });
 
-    expect(mockRecordAgentToolUsage).toHaveBeenCalledWith("web-search");
+    expect(mockRecordAgentToolUsage).toHaveBeenCalledWith(
+      "web-search",
+      "success",
+    );
   });
 
   it("does not record tool usage for non-act steps", () => {

--- a/packages/instrumentation/src/agent.ts
+++ b/packages/instrumentation/src/agent.ts
@@ -5,7 +5,11 @@ import type {
   AgentQueryInput,
 } from "./types/index.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "./types/index.js";
-import { recordAgentSteps, recordAgentToolUsage } from "./core/metrics.js";
+import {
+  recordAgentSteps,
+  recordAgentToolUsage,
+  recordAgentToolDuration,
+} from "./core/metrics.js";
 import { getConfig, shouldEmitDeprecatedAttrs } from "./core/tracer.js";
 
 const tracer = trace.getTracer(INSTRUMENTATION_NAME);
@@ -70,7 +74,11 @@ function traceAgentStep(input: AgentStepInput) {
   });
 
   if (input.type === "act" && input.toolName !== undefined) {
-    recordAgentToolUsage(input.toolName);
+    recordAgentToolUsage(input.toolName, input.toolStatus ?? "success");
+    if (input.toolDurationMs !== undefined) {
+      recordAgentToolDuration(input.toolName, input.toolDurationMs);
+      span.setAttribute("gen_ai.tool.duration_ms", input.toolDurationMs);
+    }
   }
 
   span.setStatus({ code: SpanStatusCode.OK });

--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -13,6 +13,7 @@ let requestsTotal: Counter;
 let errorsTotal: Counter;
 let agentStepsPerQuery: Histogram;
 let agentToolUsage: Counter;
+let agentToolDuration: Histogram;
 let guardEvaluations: Counter;
 let guardWouldBlock: Counter;
 let semanticDrift: Histogram;
@@ -62,8 +63,16 @@ export function initMetrics() {
   );
 
   agentToolUsage = meter.createCounter(GEN_AI_METRICS.AGENT_TOOL_USAGE, {
-    description: "Agent tool invocations by tool name",
+    description: "Agent tool invocations by tool name and status",
   });
+
+  agentToolDuration = meter.createHistogram(
+    GEN_AI_METRICS.AGENT_TOOL_DURATION,
+    {
+      description: "Agent tool execution duration in milliseconds",
+      unit: "ms",
+    },
+  );
 
   guardEvaluations = meter.createCounter(GEN_AI_METRICS.GUARD_EVALUATIONS, {
     description: "Total guard evaluations (shadow + enforce)",
@@ -189,8 +198,18 @@ export function recordAgentSteps(stepCount: number) {
   agentStepsPerQuery.record(stepCount);
 }
 
-export function recordAgentToolUsage(toolName: string) {
+export function recordAgentToolUsage(
+  toolName: string,
+  status: "success" | "error" = "success",
+) {
   agentToolUsage.add(1, {
+    [GEN_AI_ATTRS.TOOL_NAME]: toolName,
+    "tool.status": status,
+  });
+}
+
+export function recordAgentToolDuration(toolName: string, durationMs: number) {
+  agentToolDuration.record(durationMs, {
     [GEN_AI_ATTRS.TOOL_NAME]: toolName,
   });
 }

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -15,6 +15,7 @@ export const GEN_AI_METRICS = {
   // Agent metrics
   AGENT_STEPS_PER_QUERY: "gen_ai.agent.steps_per_query",
   AGENT_TOOL_USAGE: "gen_ai.agent.tool_usage",
+  AGENT_TOOL_DURATION: "gen_ai.agent.tool_duration",
   // Guard metrics
   GUARD_EVALUATIONS: "gen_ai.toad_eye.guard.evaluations",
   GUARD_WOULD_BLOCK: "gen_ai.toad_eye.guard.would_block",

--- a/packages/instrumentation/src/types/spans.ts
+++ b/packages/instrumentation/src/types/spans.ts
@@ -19,6 +19,10 @@ export interface AgentStepInput {
     | "retrieval"
     | "builtin"
     | undefined;
+  /** Duration of tool execution in milliseconds (for act steps). */
+  readonly toolDurationMs?: number | undefined;
+  /** Whether the tool execution succeeded or failed (for act steps). */
+  readonly toolStatus?: "success" | "error" | undefined;
   /** Target agent name for handoff steps */
   readonly toAgent?: string | undefined;
   /** Reason for handoff */


### PR DESCRIPTION
## Summary

- `toolDurationMs` — optional field on act steps, records tool execution time as histogram metric + span attribute
- `toolStatus` — 'success' | 'error' label on tool usage counter for success rate calculation in Grafana

Backward compatible — both fields optional, defaults to success.

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)