### PR TITLE
feat(mcp): STDIO isolation + README docs (#211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,39 @@ const result = await traceLLMCall(
 
 </details>
 
+<details>
+<summary>MCP Server observability</summary>
+
+Drop-in middleware for MCP servers — one line for full tracing of every tool call, resource read, and prompt request.
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/index.js";
+import { toadEyeMiddleware } from "toad-eye/mcp";
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+toadEyeMiddleware(server);
+
+// All handlers are now instrumented — spans appear in Jaeger
+server.tool("calculate", { expression: z.string() }, async ({ expression }) => {
+  return { content: [{ type: "text", text: String(eval(expression)) }] };
+});
+```
+
+Spans follow OTel GenAI semconv: `execute_tool calculate`, `retrieval file:///docs`, `prompt greeting`.
+
+Privacy by default — tool arguments and results are NOT recorded unless you opt in:
+
+```typescript
+toadEyeMiddleware(server, {
+  recordInputs: true,
+  redactKeys: ["apiKey", "token"],
+});
+```
+
+> Safe for stdio transport — OTel diagnostics are redirected to stderr.
+
+</details>
+
 ## Budget guards
 
 Prevent cost overruns at runtime. Three modes: warn, block, or auto-downgrade to a cheaper model.

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -124,6 +124,39 @@ const result = await traceLLMCall(
 
 </details>
 
+<details>
+<summary>MCP Server observability</summary>
+
+Drop-in middleware for MCP servers — one line for full tracing of every tool call, resource read, and prompt request.
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/index.js";
+import { toadEyeMiddleware } from "toad-eye/mcp";
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+toadEyeMiddleware(server);
+
+// All handlers are now instrumented — spans appear in Jaeger
+server.tool("calculate", { expression: z.string() }, async ({ expression }) => {
+  return { content: [{ type: "text", text: String(eval(expression)) }] };
+});
+```
+
+Spans follow OTel GenAI semconv: `execute_tool calculate`, `retrieval file:///docs`, `prompt greeting`.
+
+Privacy by default — tool arguments and results are NOT recorded unless you opt in:
+
+```typescript
+toadEyeMiddleware(server, {
+  recordInputs: true,
+  redactKeys: ["apiKey", "token"],
+});
+```
+
+> Safe for stdio transport — OTel diagnostics are redirected to stderr.
+
+</details>
+
 ## Budget guards
 
 Prevent cost overruns at runtime. Three modes: warn, block, or auto-downgrade to a cheaper model.

--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -9,7 +9,12 @@
  * and strict TypeScript. Wrapping the public API is the stable path.
  */
 
-import { context } from "@opentelemetry/api";
+import {
+  context,
+  diag,
+  DiagConsoleLogger,
+  DiagLogLevel,
+} from "@opentelemetry/api";
 import type { ToadMcpOptions } from "./types.js";
 import { extractContextFromMeta } from "./context.js";
 import {
@@ -63,11 +68,30 @@ function redactObject(
  * });
  * ```
  */
+/**
+ * Redirect OTel diagnostics to stderr to avoid polluting stdout.
+ * In stdio MCP transport, stdout IS the JSON-RPC channel —
+ * any stray console.log or OTel diagnostic would crash the connection.
+ */
+function ensureStdioSafe() {
+  const stderrLogger = new DiagConsoleLogger();
+  // Override the logger to use stderr-only methods
+  const safeLogger = {
+    verbose: (...args: unknown[]) => stderrLogger.verbose(String(args[0])),
+    debug: (...args: unknown[]) => stderrLogger.debug(String(args[0])),
+    info: (...args: unknown[]) => stderrLogger.info(String(args[0])),
+    warn: (...args: unknown[]) => stderrLogger.warn(String(args[0])),
+    error: (...args: unknown[]) => stderrLogger.error(String(args[0])),
+  };
+  diag.setLogger(safeLogger, DiagLogLevel.WARN);
+}
+
 export function toadEyeMiddleware(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server: any,
   options: ToadMcpOptions = {},
 ) {
+  ensureStdioSafe();
   const serverName: string = server.name ?? server._name ?? "mcp-server";
   const serverVersion: string = server.version ?? server._version ?? "unknown";
   const recordInputs = options.recordInputs ?? false;


### PR DESCRIPTION
## Summary

Phase 3 of MCP Server Instrumentation (#125).

- **STDIO safety:** `ensureStdioSafe()` redirects OTel diagnostics to stderr. Prevents stdout pollution that crashes stdio MCP transport.
- **README:** MCP Server observability section with usage example, privacy config, stdio safety note.

## Completes #125

All 3 phases done:
- #209 Core middleware ✅
- #210 Metrics + privacy ✅  
- #211 STDIO + docs ✅

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)