### PR TITLE
feat(mcp): traceSampling() for sampling/createMessage tracing

### DIFF
--- a/packages/instrumentation/src/__tests__/mcp/middleware.test.ts
+++ b/packages/instrumentation/src/__tests__/mcp/middleware.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { toadEyeMiddleware } from "../../mcp/index.js";
+import { toadEyeMiddleware, traceSampling } from "../../mcp/index.js";
 
 function createMockServer() {
   const tools: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
@@ -174,5 +174,40 @@ describe("toadEyeMiddleware", () => {
       "hooked-tool",
       expect.objectContaining({ data: "test" }),
     );
+  });
+});
+
+describe("traceSampling", () => {
+  it("wraps async function and returns its result", async () => {
+    const mockResponse = {
+      model: "gpt-4",
+      role: "assistant",
+      content: { type: "text", text: "Summary result" },
+    };
+
+    const result = await traceSampling(async () => mockResponse, {
+      model: "gpt-4",
+      maxTokens: 500,
+      serverName: "test-server",
+      serverVersion: "1.0.0",
+    });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("propagates errors from the sampling call", async () => {
+    await expect(
+      traceSampling(
+        async () => {
+          throw new Error("Sampling failed");
+        },
+        { model: "gpt-4" },
+      ),
+    ).rejects.toThrow("Sampling failed");
+  });
+
+  it("works with default options", async () => {
+    const result = await traceSampling(async () => ({ done: true }), {});
+    expect(result).toEqual({ done: true });
   });
 });

--- a/packages/instrumentation/src/mcp/index.ts
+++ b/packages/instrumentation/src/mcp/index.ts
@@ -1,2 +1,3 @@
-export { toadEyeMiddleware } from "./middleware.js";
+export { toadEyeMiddleware, traceSampling } from "./middleware.js";
+export type { TraceSamplingOptions } from "./middleware.js";
 export type { ToadMcpOptions, McpSpanAttributes } from "./types.js";

--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -21,6 +21,7 @@ import {
   startToolSpan,
   startResourceSpan,
   startPromptSpan,
+  startSamplingSpan,
   endSpanSuccess,
   endSpanError,
 } from "./spans.js";
@@ -272,4 +273,81 @@ export function toadEyeMiddleware(
       return originalPrompt(name, ...rest);
     };
   }
+}
+
+/**
+ * Trace a sampling/createMessage call (server → client LLM request).
+ *
+ * Sampling is an outgoing request from the MCP server to the client,
+ * asking the client's LLM to generate a response. This cannot be
+ * auto-intercepted via wrapper pattern, so wrap manually.
+ *
+ * @example
+ * ```ts
+ * import { traceSampling } from "toad-eye/mcp";
+ *
+ * server.tool("summarize", { text: z.string() }, async ({ text }, ctx) => {
+ *   const response = await traceSampling(
+ *     () => ctx.mcpReq.requestSampling({
+ *       messages: [{ role: "user", content: { type: "text", text } }],
+ *       maxTokens: 500,
+ *     }),
+ *     { model: "gpt-4" }
+ *   );
+ *   return { content: [{ type: "text", text: response.content.text }] };
+ * });
+ * ```
+ */
+export async function traceSampling<T>(
+  fn: () => Promise<T>,
+  options: TraceSamplingOptions,
+): Promise<T> {
+  const model = options.model ?? "unknown";
+  const span = startSamplingSpan(model, {
+    serverName: options.serverName ?? "mcp-server",
+    serverVersion: options.serverVersion ?? "unknown",
+    parentContext: options.parentContext,
+  });
+
+  if (options.maxTokens !== undefined) {
+    span.setAttribute("gen_ai.request.max_tokens", options.maxTokens);
+  }
+
+  const start = performance.now();
+  try {
+    const result = await fn();
+    const durationMs = performance.now() - start;
+
+    // Extract token usage from response if available
+    const response = result as Record<string, unknown> | null;
+    if (response && typeof response === "object") {
+      if (response["model"]) {
+        span.setAttribute("gen_ai.response.model", String(response["model"]));
+      }
+    }
+
+    span.setAttribute("gen_ai.mcp.sampling.duration_ms", durationMs);
+    endSpanSuccess(span);
+    return result;
+  } catch (error) {
+    endSpanError(span, error);
+    throw error;
+  }
+}
+
+export interface TraceSamplingOptions {
+  /** The model being requested for sampling. */
+  readonly model?: string | undefined;
+
+  /** Max tokens requested. */
+  readonly maxTokens?: number | undefined;
+
+  /** MCP server name for span attributes. */
+  readonly serverName?: string | undefined;
+
+  /** MCP server version for span attributes. */
+  readonly serverVersion?: string | undefined;
+
+  /** Parent OTel context. */
+  readonly parentContext?: import("@opentelemetry/api").Context | undefined;
 }

--- a/packages/instrumentation/src/mcp/spans.ts
+++ b/packages/instrumentation/src/mcp/spans.ts
@@ -2,9 +2,10 @@
  * OTel span creation for MCP operations.
  *
  * Maps MCP methods to OTel GenAI semantic conventions:
- * - tools/call       → execute_tool {tool_name}
- * - resources/read   → retrieval {uri}
- * - prompts/get      → prompt {name}
+ * - tools/call              → execute_tool {tool_name}
+ * - resources/read          → retrieval {uri}
+ * - prompts/get             → prompt {name}
+ * - sampling/createMessage  → chat {model}
  */
 
 import {
@@ -64,6 +65,28 @@ export function startPromptSpan(promptName: string, options: SpanOptions) {
       attributes: {
         "gen_ai.operation.name": "prompt",
         "gen_ai.prompt.name": promptName,
+        "mcp.server.name": options.serverName,
+        "mcp.server.version": options.serverVersion,
+      },
+    },
+    options.parentContext,
+  );
+}
+
+export interface SamplingSpanOptions {
+  readonly serverName: string;
+  readonly serverVersion: string;
+  readonly parentContext?: Context | undefined;
+}
+
+export function startSamplingSpan(model: string, options: SamplingSpanOptions) {
+  return tracer.startSpan(
+    `chat ${model}`,
+    {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": model,
         "mcp.server.name": options.serverName,
         "mcp.server.version": options.serverVersion,
       },


### PR DESCRIPTION
## Summary

- **`traceSampling()`** — wrapper for MCP server → client LLM sampling requests
- Creates `chat {model}` spans with `SpanKind.CLIENT` (outgoing request)
- Captures: model, maxTokens, duration, response model
- Exported from `toad-eye/mcp` alongside `toadEyeMiddleware`

## Why not auto-instrumented?

`sampling/createMessage` is an **outgoing** request from server to client (unlike tools/resources/prompts which are incoming handlers). Auto-intercepting would require monkey-patching SDK internals (`requestSampling()` on the session object), which is fragile given the SDK is still evolving. Manual wrapper is the stable approach.

## Usage

```typescript
import { toadEyeMiddleware, traceSampling } from "toad-eye/mcp";

server.tool("summarize", { text: z.string() }, async ({ text }, ctx) => {
  const response = await traceSampling(
    () => ctx.mcpReq.requestSampling({
      messages: [{ role: "user", content: { type: "text", text } }],
      maxTokens: 500,
    }),
    { model: "gpt-4", maxTokens: 500 }
  );
  return { content: [{ type: "text", text: response.content.text }] };
});
```

## Test plan

- [x] 15/15 MCP tests pass (3 new for traceSampling)
- [x] Build passes
- [x] Typecheck passes

## Part of #215 (Follow-up 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)