### PR TITLE
fix: 3 bugs from code review — error.type, sparse array, partial patch

### DIFF
--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -468,6 +468,11 @@ export function createInstrumentation(config: {
 
         return activePatches.length > 0;
       } catch (err) {
+        // Clean up any patches applied before the failure
+        for (const { proto, method, original } of activePatches) {
+          proto[method] = original;
+        }
+        activePatches.length = 0;
         diag.warn(`toad-eye: failed to patch ${config.name}: ${err}`);
         return false;
       }

--- a/packages/instrumentation/src/instrumentations/openai.ts
+++ b/packages/instrumentation/src/instrumentations/openai.ts
@@ -73,6 +73,10 @@ const chatCompletions: PatchTarget = {
           if (tc.function?.arguments)
             existing.arguments += tc.function.arguments;
         } else {
+          // Fill gaps to avoid sparse array with non-contiguous indices
+          while (acc.toolCalls.length < tc.index) {
+            acc.toolCalls.push({ name: "", arguments: "" });
+          }
           acc.toolCalls[tc.index] = {
             name: tc.function?.name ?? "",
             arguments: tc.function?.arguments ?? "",

--- a/packages/instrumentation/src/mcp/spans.ts
+++ b/packages/instrumentation/src/mcp/spans.ts
@@ -105,7 +105,9 @@ export function endSpanError(
   error: unknown,
 ) {
   const message = error instanceof Error ? error.message : String(error);
+  const errorType =
+    error instanceof Error ? error.constructor.name : "UnknownError";
   span.setStatus({ code: SpanStatusCode.ERROR, message });
-  span.setAttribute("error.type", message);
+  span.setAttribute("error.type", errorType);
   span.end();
 }


### PR DESCRIPTION
## Summary

Fixes 3 bugs found during comprehensive code review.

- **B2:** MCP `endSpanError()` set `error.type` to error message instead of class name (OTel semconv violation). Fixed to use `error.constructor.name`.
- **B3:** OpenAI streaming `tool_calls` created sparse array via direct index assignment. Added gap-filling to ensure contiguous array.
- **B4:** `createInstrumentation().enable()` left partial patches active on error. Added cleanup in catch block.
- **B1:** False positive — `recordResponseEmpty` already checks raw `output.completion`, not the hashed version.

## Test plan

- [x] 219/219 tests pass
- [x] Build passes
- [x] Typecheck passes

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)