### PR TITLE
fix: metric accuracy — skip error count for budget blocks, cap warnedModels

### DIFF
--- a/packages/instrumentation/src/core/pricing.ts
+++ b/packages/instrumentation/src/core/pricing.ts
@@ -108,6 +108,7 @@ export function calculateCost(
   const pricing = getModelPricing(model);
   if (!pricing) {
     if (inputTokens + outputTokens > 0 && !warnedModels.has(model)) {
+      if (warnedModels.size >= 100) warnedModels.clear();
       warnedModels.add(model);
       console.warn(
         `toad-eye: unknown pricing for "${model}" — cost reported as $0. Use setCustomPricing() to set rates.`,

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -372,16 +372,18 @@ export async function traceLLMCall(
           effectiveInput.model,
           attrs,
         );
-        recordError(effectiveInput.provider, effectiveInput.model, attrs);
 
         // Release cost reservation on any error (no cost was incurred)
         if (budget) {
           budget.releaseReservation(estimatedCost);
         }
 
-        // If this was a budget block, record the metric with the correct budget type
         if (error instanceof ToadBudgetExceededError) {
+          // Budget blocks are intentional guardrails, not errors — record
+          // only the budget-specific metric to avoid inflating error rate
           recordBudgetBlocked(error.budget);
+        } else {
+          recordError(effectiveInput.provider, effectiveInput.model, attrs);
         }
 
         throw error;


### PR DESCRIPTION
## Summary

- **L2:** `ToadBudgetExceededError` no longer double-counts in error metrics. Budget blocks record only `gen_ai.toad_eye.budget.blocked`, not `gen_ai.client.errors`.
- **L3:** `warnedModels` Set capped at 100 entries — prevents unbounded memory growth with dynamic model names.

## Test plan

- [x] 219/219 tests pass
- [x] Build passes

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)