### PR TITLE
feat(mcp): add standard MCP semconv attributes

### DIFF
--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -15,6 +15,7 @@ import {
   DiagConsoleLogger,
   DiagLogLevel,
 } from "@opentelemetry/api";
+import { randomUUID } from "node:crypto";
 import type { ToadMcpOptions } from "./types.js";
 import { extractContextFromMeta } from "./context.js";
 import {
@@ -33,6 +34,19 @@ import {
 } from "./metrics.js";
 
 const DEFAULT_MAX_PAYLOAD_SIZE = 4096;
+
+/** Detect MCP transport type from server internals. */
+function detectTransport(server: Record<string, unknown>): string {
+  // Check if server has a transport reference
+  const transport = server.transport ?? server._transport;
+  if (transport && typeof transport === "object") {
+    const name = (transport as Record<string, unknown>).constructor?.name ?? "";
+    if (/stdio/i.test(name)) return "pipe";
+    if (/sse|http/i.test(name)) return "tcp";
+  }
+  // Default: stdio is most common for local dev
+  return "pipe";
+}
 
 function truncate(value: string, maxBytes: number): string {
   if (value.length <= maxBytes) return value;
@@ -103,7 +117,24 @@ export function toadEyeMiddleware(
   const maxPayload = options.maxPayloadSize ?? DEFAULT_MAX_PAYLOAD_SIZE;
   const propagate = options.propagateContext ?? true;
 
-  const spanOpts = { serverName, serverVersion };
+  // Session ID: explicit > server-provided > generated
+  const sessionId =
+    options.sessionId ?? server.sessionId ?? randomUUID().slice(0, 8);
+
+  // Protocol version from server capabilities or default
+  const protocolVersion: string =
+    server.protocolVersion ?? server._protocolVersion ?? "2025-03-26";
+
+  // Detect transport type: pipe (stdio) vs tcp (HTTP)
+  const networkTransport = detectTransport(server);
+
+  const spanOpts = {
+    serverName,
+    serverVersion,
+    sessionId,
+    protocolVersion,
+    networkTransport,
+  };
 
   // --- Wrap .tool() ---
   const originalTool = server.tool.bind(server);
@@ -309,6 +340,9 @@ export async function traceSampling<T>(
     serverName: options.serverName ?? "mcp-server",
     serverVersion: options.serverVersion ?? "unknown",
     parentContext: options.parentContext,
+    sessionId: options.sessionId,
+    protocolVersion: options.protocolVersion,
+    networkTransport: options.networkTransport,
   });
 
   if (options.maxTokens !== undefined) {
@@ -352,4 +386,13 @@ export interface TraceSamplingOptions {
 
   /** Parent OTel context. */
   readonly parentContext?: import("@opentelemetry/api").Context | undefined;
+
+  /** MCP session ID. */
+  readonly sessionId?: string | undefined;
+
+  /** MCP protocol version. */
+  readonly protocolVersion?: string | undefined;
+
+  /** Network transport: "pipe" (stdio) or "tcp" (HTTP). */
+  readonly networkTransport?: string | undefined;
 }

--- a/packages/instrumentation/src/mcp/spans.ts
+++ b/packages/instrumentation/src/mcp/spans.ts
@@ -31,6 +31,25 @@ export interface SpanOptions {
   readonly serverName: string;
   readonly serverVersion: string;
   readonly parentContext: Context;
+  readonly sessionId?: string | undefined;
+  readonly protocolVersion?: string | undefined;
+  readonly networkTransport?: string | undefined;
+}
+
+/** Build common MCP attributes shared across all span types. */
+function baseAttrs(method: string, options: SpanOptions | SamplingSpanOptions) {
+  const attrs: Record<string, string> = {
+    "gen_ai.operation.name": method,
+    "mcp.method.name": method,
+    "mcp.server.name": options.serverName,
+    "mcp.server.version": options.serverVersion,
+  };
+  if (options.sessionId) attrs["mcp.session.id"] = options.sessionId;
+  if (options.protocolVersion)
+    attrs["mcp.protocol.version"] = options.protocolVersion;
+  if (options.networkTransport)
+    attrs["network.transport"] = options.networkTransport;
+  return attrs;
 }
 
 export function startToolSpan(toolName: string, options: SpanOptions) {
@@ -39,11 +58,8 @@ export function startToolSpan(toolName: string, options: SpanOptions) {
     {
       kind: SpanKind.INTERNAL,
       attributes: {
-        "gen_ai.operation.name": MCP_METHODS.TOOLS_CALL,
-        "mcp.method.name": MCP_METHODS.TOOLS_CALL,
+        ...baseAttrs(MCP_METHODS.TOOLS_CALL, options),
         "gen_ai.tool.name": toolName,
-        "mcp.server.name": options.serverName,
-        "mcp.server.version": options.serverVersion,
       },
     },
     options.parentContext,
@@ -56,11 +72,8 @@ export function startResourceSpan(uri: string, options: SpanOptions) {
     {
       kind: SpanKind.INTERNAL,
       attributes: {
-        "gen_ai.operation.name": MCP_METHODS.RESOURCES_READ,
-        "mcp.method.name": MCP_METHODS.RESOURCES_READ,
+        ...baseAttrs(MCP_METHODS.RESOURCES_READ, options),
         "gen_ai.data_source.id": uri,
-        "mcp.server.name": options.serverName,
-        "mcp.server.version": options.serverVersion,
       },
     },
     options.parentContext,
@@ -73,11 +86,8 @@ export function startPromptSpan(promptName: string, options: SpanOptions) {
     {
       kind: SpanKind.INTERNAL,
       attributes: {
-        "gen_ai.operation.name": MCP_METHODS.PROMPTS_GET,
-        "mcp.method.name": MCP_METHODS.PROMPTS_GET,
+        ...baseAttrs(MCP_METHODS.PROMPTS_GET, options),
         "gen_ai.prompt.name": promptName,
-        "mcp.server.name": options.serverName,
-        "mcp.server.version": options.serverVersion,
       },
     },
     options.parentContext,
@@ -88,6 +98,9 @@ export interface SamplingSpanOptions {
   readonly serverName: string;
   readonly serverVersion: string;
   readonly parentContext?: Context | undefined;
+  readonly sessionId?: string | undefined;
+  readonly protocolVersion?: string | undefined;
+  readonly networkTransport?: string | undefined;
 }
 
 export function startSamplingSpan(model: string, options: SamplingSpanOptions) {
@@ -96,11 +109,8 @@ export function startSamplingSpan(model: string, options: SamplingSpanOptions) {
     {
       kind: SpanKind.CLIENT,
       attributes: {
-        "gen_ai.operation.name": MCP_METHODS.SAMPLING_CREATE_MESSAGE,
-        "mcp.method.name": MCP_METHODS.SAMPLING_CREATE_MESSAGE,
+        ...baseAttrs(MCP_METHODS.SAMPLING_CREATE_MESSAGE, options),
         "gen_ai.request.model": model,
-        "mcp.server.name": options.serverName,
-        "mcp.server.version": options.serverVersion,
       },
     },
     options.parentContext,
@@ -121,5 +131,12 @@ export function endSpanError(
     error instanceof Error ? error.constructor.name : "UnknownError";
   span.setStatus({ code: SpanStatusCode.ERROR, message });
   span.setAttribute("error.type", errorType);
+
+  // JSON-RPC error code if available (MCP SDK errors often carry a code)
+  const code = (error as Record<string, unknown> | null)?.code;
+  if (typeof code === "number") {
+    span.setAttribute("rpc.response.status_code", code);
+  }
+
   span.end();
 }

--- a/packages/instrumentation/src/mcp/types.ts
+++ b/packages/instrumentation/src/mcp/types.ts
@@ -20,6 +20,9 @@ export interface ToadMcpOptions {
   /** Max payload size in bytes before truncation. Default: 4096. */
   readonly maxPayloadSize?: number | undefined;
 
+  /** Explicit session ID. Auto-generated if not provided. */
+  readonly sessionId?: string | undefined;
+
   /** Extract W3C traceparent from _meta field. Default: true. */
   readonly propagateContext?: boolean | undefined;
 
@@ -35,12 +38,15 @@ export interface ToadMcpOptions {
 /** OTel attributes set on MCP spans. */
 export interface McpSpanAttributes {
   readonly "gen_ai.operation.name": string;
+  readonly "mcp.method.name": string;
   readonly "gen_ai.tool.name"?: string;
   readonly "gen_ai.tool.call.id"?: string;
   readonly "gen_ai.data_source.id"?: string;
   readonly "gen_ai.prompt.name"?: string;
   readonly "mcp.server.name": string;
   readonly "mcp.server.version": string;
-  readonly "mcp.transport"?: "stdio" | "sse" | "streamable-http";
   readonly "mcp.session.id"?: string;
+  readonly "mcp.protocol.version"?: string;
+  readonly "network.transport"?: "pipe" | "tcp";
+  readonly "rpc.response.status_code"?: number;
 }


### PR DESCRIPTION
## Summary

Closes #233

Add OTel MCP semantic convention attributes to all MCP spans:

- **`mcp.session.id`** — auto-generated UUID (first 8 chars) or explicit via `sessionId` option
- **`mcp.protocol.version`** — read from server or defaults to `"2025-03-26"`
- **`network.transport`** — auto-detected from server transport: `"pipe"` (stdio) or `"tcp"` (HTTP/SSE)
- **`rpc.response.status_code`** — JSON-RPC error code on error spans (when available)

Also:
- Extract common attribute building into `baseAttrs()` helper (DRYs up 4 span functions)
- Add `sessionId` to `ToadMcpOptions` and `TraceSamplingOptions`
- Update `McpSpanAttributes` type with all new fields
- Add `detectTransport()` for automatic transport type detection

## Test plan

- [x] 219 unit tests pass
- [x] TypeScript build clean
- [ ] Manual: run MCP demo, verify `mcp.session.id`, `mcp.protocol.version`, `network.transport` appear on spans in Jaeger

🤖 Generated with [Claude Code](https://claude.com/claude-code)