### PR TITLE
feat(mcp): auto-instrumentation via instrument: ["mcp"]

### DIFF
--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -13,6 +13,10 @@ import type { ToadEyeConfig } from "../types/index.js";
 import { initMetrics, resetMetrics } from "./metrics.js";
 import { resetCustomPricing } from "./pricing.js";
 import { enableAll, disableAll } from "../instrumentations/registry.js";
+import {
+  enableMcpInstrumentation,
+  disableMcpInstrumentation,
+} from "../instrumentations/mcp.js";
 import { BudgetTracker } from "../budget/index.js";
 import { ToadEyeAISpanProcessor } from "../vercel.js";
 import type { LLMProvider } from "../types/index.js";
@@ -169,9 +173,19 @@ export function initObservability(config: ToadEyeConfig) {
   }
 
   if (config.instrument?.length) {
-    // Filter out 'ai' — it uses SpanProcessor, not monkey-patching
+    // Handle MCP auto-instrumentation separately
+    if (config.instrument.includes("mcp")) {
+      const patched = enableMcpInstrumentation();
+      if (!patched) {
+        console.warn(
+          `toad-eye: "@modelcontextprotocol/sdk" not found — install it to enable MCP auto-instrumentation`,
+        );
+      }
+    }
+
+    // Filter out 'ai' and 'mcp' — they use separate mechanisms
     const patchProviders = config.instrument.filter(
-      (i): i is LLMProvider => i !== "ai",
+      (i): i is LLMProvider => i !== "ai" && i !== "mcp",
     );
     if (patchProviders.length > 0) {
       // enableAll is async (lazy-loads provider modules on first call).
@@ -188,6 +202,7 @@ export function initObservability(config: ToadEyeConfig) {
 export async function shutdown() {
   if (!sdk) return;
   disableAll();
+  disableMcpInstrumentation();
   await sdk.shutdown();
   sdk = null;
   currentConfig = null;

--- a/packages/instrumentation/src/instrumentations/mcp.ts
+++ b/packages/instrumentation/src/instrumentations/mcp.ts
@@ -1,0 +1,97 @@
+/**
+ * Auto-instrumentation for MCP SDK.
+ *
+ * Patches McpServer.prototype so that any server instance created after
+ * enableMcpInstrumentation() is automatically instrumented — no need
+ * to call toadEyeMiddleware(server) manually.
+ *
+ * Uses __toad_eye_mcp_patched flag to prevent double-instrumentation
+ * when both auto and manual approaches are used.
+ */
+
+import { createRequire } from "node:module";
+import { toadEyeMiddleware } from "../mcp/middleware.js";
+
+const require = createRequire(import.meta.url);
+
+const PATCHED_FLAG = "__toad_eye_mcp_patched";
+const MODULE_NAME = "@modelcontextprotocol/sdk/server/mcp.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mcpServerProto: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let originals: { tool: any; resource?: any; prompt?: any } | null = null;
+
+export function enableMcpInstrumentation(): boolean {
+  try {
+    require.resolve(MODULE_NAME);
+  } catch {
+    return false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const sdk = require(MODULE_NAME);
+  const McpServer = sdk.McpServer ?? sdk.default?.McpServer;
+
+  if (!McpServer?.prototype) return false;
+  if (McpServer.prototype[PATCHED_FLAG]) return true;
+
+  const proto = McpServer.prototype;
+  mcpServerProto = proto;
+
+  originals = {
+    tool: proto.tool,
+    resource: proto.resource,
+    prompt: proto.prompt,
+  };
+
+  // WeakSet tracks which instances have been instrumented
+  const instrumented = new WeakSet();
+
+  function ensureInstrumented(instance: Record<string, unknown>) {
+    if (instrumented.has(instance)) return;
+    instrumented.add(instance);
+
+    // Restore original methods so middleware wraps the real ones
+    instance.tool = originals!.tool.bind(instance);
+    if (originals!.resource)
+      instance.resource = originals!.resource.bind(instance);
+    if (originals!.prompt) instance.prompt = originals!.prompt.bind(instance);
+
+    toadEyeMiddleware(instance);
+  }
+
+  proto.tool = function patchedTool(...args: unknown[]): unknown {
+    ensureInstrumented(this);
+    return this.tool(...args);
+  };
+
+  if (originals.resource) {
+    proto.resource = function patchedResource(...args: unknown[]): unknown {
+      ensureInstrumented(this);
+      return this.resource(...args);
+    };
+  }
+
+  if (originals.prompt) {
+    proto.prompt = function patchedPrompt(...args: unknown[]): unknown {
+      ensureInstrumented(this);
+      return this.prompt(...args);
+    };
+  }
+
+  proto[PATCHED_FLAG] = true;
+  return true;
+}
+
+export function disableMcpInstrumentation() {
+  if (!mcpServerProto || !originals) return;
+
+  mcpServerProto.tool = originals.tool;
+  if (originals.resource) mcpServerProto.resource = originals.resource;
+  if (originals.prompt) mcpServerProto.prompt = originals.prompt;
+  delete mcpServerProto[PATCHED_FLAG];
+
+  mcpServerProto = null;
+  originals = null;
+}

--- a/packages/instrumentation/src/types/providers.ts
+++ b/packages/instrumentation/src/types/providers.ts
@@ -7,5 +7,6 @@ export type LLMProvider = "anthropic" | "gemini" | "openai" | (string & {});
 /**
  * All instrumentable targets — includes LLM providers + framework SDKs.
  * 'ai' = Vercel AI SDK (uses SpanProcessor, not monkey-patching).
+ * 'mcp' = MCP SDK McpServer (patches prototype for auto-instrumentation).
  */
-export type InstrumentTarget = LLMProvider | "ai";
+export type InstrumentTarget = LLMProvider | "ai" | "mcp";


### PR DESCRIPTION
## Summary

Closes #236, part of #229

Add MCP auto-instrumentation — `instrument: ["mcp"]` patches `McpServer.prototype` so any server instance is automatically instrumented without calling `toadEyeMiddleware()` manually.

```typescript
initObservability({
  serviceName: "my-app",
  instrument: ["mcp"],  // that's it — all MCP servers are traced
});
```

### How it works

- Patches `.tool()`, `.resource()`, `.prompt()` on `McpServer.prototype`
- On first handler registration, restores originals and applies `toadEyeMiddleware()`
- Uses `WeakSet` to track instrumented instances — safe when `toadEyeMiddleware()` is also called manually
- `__toad_eye_mcp_patched` flag on prototype prevents double-patching
- Uses `createRequire()` for ESM compatibility (same pattern as OpenAI/Anthropic instrumentations)

### Changes

- New: `src/instrumentations/mcp.ts`
- Updated: `src/core/tracer.ts` — wire `"mcp"` into init/shutdown
- Updated: `src/types/providers.ts` — add `"mcp"` to `InstrumentTarget`

## Test plan

- [x] 219 unit tests pass
- [x] TypeScript build clean
- [ ] Manual: use `instrument: ["mcp"]` without `toadEyeMiddleware()`, verify spans appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)