### PR TITLE
chore: add MCP SDK version compatibility CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,20 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm run format:check
       - run: npm run test --workspace=packages/instrumentation
+
+  mcp-sdk-compat:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mcp-sdk-version: ["1.12.1", "1.27.1", "latest"]
+    name: MCP SDK v${{ matrix.mcp-sdk-version }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm install @modelcontextprotocol/sdk@${{ matrix.mcp-sdk-version }} --workspace=demo --save-dev --no-audit
+      - run: npm run build --workspace=packages/instrumentation
+      - run: npm run test --workspace=packages/instrumentation

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -161,6 +161,8 @@ toadEyeMiddleware(server, {
 Dedicated MCP dashboard in Grafana: tool call rate, duration p50/p95, error rate, resource reads, tool performance table.
 
 > Safe for stdio transport — OTel diagnostics are redirected to stderr.
+>
+> **Supported MCP SDK versions:** `@modelcontextprotocol/sdk` v1.12+ (tested in CI against v1.12, v1.27, and latest).
 
 ## Budget guards
 


### PR DESCRIPTION
## Summary

Closes #240, completes #229 (Epic 2)

- Add `mcp-sdk-compat` CI matrix job that tests against MCP SDK v1.12.1, v1.27.1, and latest
- Document supported SDK version range in README (`v1.12+`)

Ensures we catch breaking changes when MCP SDK releases new versions.

## Test plan

- [x] 219 unit tests pass
- [x] CI workflow YAML is valid
- [ ] CI runs the matrix job on PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)