### PR TITLE
feat(mcp): client-side instrumentation with distributed tracing

### DIFF
--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -17,6 +17,10 @@ import {
   enableMcpInstrumentation,
   disableMcpInstrumentation,
 } from "../instrumentations/mcp.js";
+import {
+  enableMcpClientInstrumentation,
+  disableMcpClientInstrumentation,
+} from "../mcp/client.js";
 import { BudgetTracker } from "../budget/index.js";
 import { ToadEyeAISpanProcessor } from "../vercel.js";
 import type { LLMProvider } from "../types/index.js";
@@ -173,19 +177,29 @@ export function initObservability(config: ToadEyeConfig) {
   }
 
   if (config.instrument?.length) {
-    // Handle MCP auto-instrumentation separately
+    // Handle MCP server auto-instrumentation
     if (config.instrument.includes("mcp")) {
       const patched = enableMcpInstrumentation();
       if (!patched) {
         console.warn(
-          `toad-eye: "@modelcontextprotocol/sdk" not found — install it to enable MCP auto-instrumentation`,
+          `toad-eye: "@modelcontextprotocol/sdk" not found — install it to enable MCP server auto-instrumentation`,
         );
       }
     }
 
-    // Filter out 'ai' and 'mcp' — they use separate mechanisms
+    // Handle MCP client auto-instrumentation
+    if (config.instrument.includes("mcp-client")) {
+      const patched = enableMcpClientInstrumentation();
+      if (!patched) {
+        console.warn(
+          `toad-eye: "@modelcontextprotocol/sdk" not found — install it to enable MCP client auto-instrumentation`,
+        );
+      }
+    }
+
+    // Filter out special targets — they use separate mechanisms
     const patchProviders = config.instrument.filter(
-      (i): i is LLMProvider => i !== "ai" && i !== "mcp",
+      (i): i is LLMProvider => i !== "ai" && i !== "mcp" && i !== "mcp-client",
     );
     if (patchProviders.length > 0) {
       // enableAll is async (lazy-loads provider modules on first call).
@@ -203,6 +217,7 @@ export async function shutdown() {
   if (!sdk) return;
   disableAll();
   disableMcpInstrumentation();
+  disableMcpClientInstrumentation();
   await sdk.shutdown();
   sdk = null;
   currentConfig = null;

--- a/packages/instrumentation/src/mcp/client.ts
+++ b/packages/instrumentation/src/mcp/client.ts
@@ -1,0 +1,206 @@
+/**
+ * MCP Client instrumentation — patches Client.prototype to create
+ * SpanKind.CLIENT spans for outgoing tool calls, resource reads, and prompt gets.
+ *
+ * Injects W3C traceparent into _meta field so server-side middleware
+ * can link client and server spans into one distributed trace.
+ */
+
+import { createRequire } from "node:module";
+import {
+  trace,
+  context,
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+} from "@opentelemetry/api";
+import { MCP_METHODS } from "./spans.js";
+
+const require = createRequire(import.meta.url);
+
+const TRACER_NAME = "toad-eye-mcp-client";
+const PATCHED_FLAG = "__toad_eye_mcp_client_patched";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let clientProto: any = null;
+let originals: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callTool: (...args: any[]) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readResource: (...args: any[]) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getPrompt: (...args: any[]) => Promise<any>;
+} | null = null;
+
+/**
+ * Inject W3C traceparent into MCP _meta field.
+ * This allows server-side middleware to extract parent context.
+ */
+function injectTraceContext(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const meta = (params._meta as Record<string, unknown>) ?? {};
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+
+  if (carrier["traceparent"]) {
+    return {
+      ...params,
+      _meta: {
+        ...meta,
+        traceparent: carrier["traceparent"],
+        ...(carrier["tracestate"] ? { tracestate: carrier["tracestate"] } : {}),
+      },
+    };
+  }
+  return params;
+}
+
+export function enableMcpClientInstrumentation(): boolean {
+  try {
+    require.resolve("@modelcontextprotocol/sdk/client/index.js");
+  } catch {
+    return false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const sdk = require("@modelcontextprotocol/sdk/client/index.js");
+  const Client = sdk.Client ?? sdk.default?.Client;
+
+  if (!Client?.prototype) return false;
+  if (Client.prototype[PATCHED_FLAG]) return true;
+
+  const proto = Client.prototype;
+  clientProto = proto;
+
+  originals = {
+    callTool: proto.callTool,
+    readResource: proto.readResource,
+    getPrompt: proto.getPrompt,
+  };
+
+  const tracer = trace.getTracer(TRACER_NAME);
+
+  // --- Patch callTool ---
+  proto.callTool = async function patchedCallTool(
+    params: Record<string, unknown>,
+    ...rest: unknown[]
+  ) {
+    const toolName = (params.name as string) ?? "unknown";
+    const span = tracer.startSpan(`${MCP_METHODS.TOOLS_CALL} ${toolName}`, {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        "gen_ai.operation.name": MCP_METHODS.TOOLS_CALL,
+        "mcp.method.name": MCP_METHODS.TOOLS_CALL,
+        "gen_ai.tool.name": toolName,
+      },
+    });
+
+    const enrichedParams = injectTraceContext(params);
+
+    try {
+      const result = await context.with(
+        trace.setSpan(context.active(), span),
+        () => originals!.callTool.call(this, enrichedParams, ...rest),
+      );
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const errorType =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      span.setAttribute("error.type", errorType);
+      span.end();
+      throw error;
+    }
+  };
+
+  // --- Patch readResource ---
+  proto.readResource = async function patchedReadResource(
+    params: Record<string, unknown>,
+    ...rest: unknown[]
+  ) {
+    const uri = (params.uri as string) ?? "unknown";
+    const span = tracer.startSpan(`${MCP_METHODS.RESOURCES_READ} ${uri}`, {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        "gen_ai.operation.name": MCP_METHODS.RESOURCES_READ,
+        "mcp.method.name": MCP_METHODS.RESOURCES_READ,
+        "gen_ai.data_source.id": uri,
+      },
+    });
+
+    const enrichedParams = injectTraceContext(params);
+
+    try {
+      const result = await context.with(
+        trace.setSpan(context.active(), span),
+        () => originals!.readResource.call(this, enrichedParams, ...rest),
+      );
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const errorType =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      span.setAttribute("error.type", errorType);
+      span.end();
+      throw error;
+    }
+  };
+
+  // --- Patch getPrompt ---
+  proto.getPrompt = async function patchedGetPrompt(
+    params: Record<string, unknown>,
+    ...rest: unknown[]
+  ) {
+    const promptName = (params.name as string) ?? "unknown";
+    const span = tracer.startSpan(`${MCP_METHODS.PROMPTS_GET} ${promptName}`, {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        "gen_ai.operation.name": MCP_METHODS.PROMPTS_GET,
+        "mcp.method.name": MCP_METHODS.PROMPTS_GET,
+        "gen_ai.prompt.name": promptName,
+      },
+    });
+
+    const enrichedParams = injectTraceContext(params);
+
+    try {
+      const result = await context.with(
+        trace.setSpan(context.active(), span),
+        () => originals!.getPrompt.call(this, enrichedParams, ...rest),
+      );
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const errorType =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      span.setAttribute("error.type", errorType);
+      span.end();
+      throw error;
+    }
+  };
+
+  proto[PATCHED_FLAG] = true;
+  return true;
+}
+
+export function disableMcpClientInstrumentation() {
+  if (!clientProto || !originals) return;
+
+  clientProto.callTool = originals.callTool;
+  clientProto.readResource = originals.readResource;
+  clientProto.getPrompt = originals.getPrompt;
+  delete clientProto[PATCHED_FLAG];
+
+  clientProto = null;
+  originals = null;
+}

--- a/packages/instrumentation/src/mcp/index.ts
+++ b/packages/instrumentation/src/mcp/index.ts
@@ -2,3 +2,7 @@ export { toadEyeMiddleware, traceSampling } from "./middleware.js";
 export type { TraceSamplingOptions } from "./middleware.js";
 export type { ToadMcpOptions, McpSpanAttributes } from "./types.js";
 export { MCP_METHODS } from "./spans.js";
+export {
+  enableMcpClientInstrumentation,
+  disableMcpClientInstrumentation,
+} from "./client.js";

--- a/packages/instrumentation/src/types/providers.ts
+++ b/packages/instrumentation/src/types/providers.ts
@@ -8,5 +8,6 @@ export type LLMProvider = "anthropic" | "gemini" | "openai" | (string & {});
  * All instrumentable targets — includes LLM providers + framework SDKs.
  * 'ai' = Vercel AI SDK (uses SpanProcessor, not monkey-patching).
  * 'mcp' = MCP SDK McpServer (patches prototype for auto-instrumentation).
+ * 'mcp-client' = MCP SDK Client (patches callTool/readResource/getPrompt for distributed tracing).
  */
-export type InstrumentTarget = LLMProvider | "ai" | "mcp";
+export type InstrumentTarget = LLMProvider | "ai" | "mcp" | "mcp-client";


### PR DESCRIPTION
## Summary

Closes #241, part of #230

Instrument MCP Client to create `SpanKind.CLIENT` spans and inject W3C traceparent for distributed tracing.

```typescript
initObservability({
  serviceName: "my-agent",
  instrument: ["mcp-client"],  // patches Client.prototype
});

// Now every client.callTool() creates a CLIENT span
// linked to the SERVER span via traceparent in _meta
```

### How it works

1. Patches `Client.prototype.callTool`, `readResource`, `getPrompt`
2. Creates `SpanKind.CLIENT` spans with MCP semconv attributes
3. Injects `traceparent` into `_meta` field of JSON-RPC params
4. Server-side middleware (from #233) extracts context → spans linked

### Result in Jaeger

```
tools/call calculate  (CLIENT, my-agent)
└── tools/call calculate  (SERVER, my-mcp-server)
```

One trace, both sides visible.

## Test plan

- [x] 219 unit tests pass
- [x] TypeScript build clean
- [ ] Manual: end-to-end demo with client + server, verify linked spans in Jaeger

🤖 Generated with [Claude Code](https://claude.com/claude-code)