### PR TITLE
feat(alerts): add MCP alert rule templates

### DIFF
--- a/packages/instrumentation/templates/alerts.example.yml
+++ b/packages/instrumentation/templates/alerts.example.yml
@@ -52,3 +52,24 @@ alerts:
     condition: ratio_5m > 0.2
     channels: [slack]
     cooldown: 15
+
+  # --- MCP Server alerts ---
+
+  # MCP tool error rate: >10% over 5 minutes
+  - name: mcp_tool_error_rate
+    metric: gen_ai.mcp.tool.errors
+    condition: ratio_5m > 0.1
+    channels: [slack]
+
+  # MCP tool latency spike: avg > 2 seconds over 5 minutes
+  - name: mcp_tool_latency
+    metric: gen_ai.mcp.tool.duration
+    condition: avg_5m > 2000
+    channels: [slack]
+
+  # MCP tool call spike: >100 calls in 5 minutes
+  - name: mcp_tool_call_spike
+    metric: gen_ai.mcp.tool.calls
+    condition: sum_5m > 100
+    channels: [slack]
+    cooldown: 15


### PR DESCRIPTION
## Summary

Closes #245, part of #231

Add 3 pre-built MCP alert rules to `alerts.example.yml`:

- **mcp_tool_error_rate** — tool error ratio > 10% over 5 minutes
- **mcp_tool_latency** — avg tool duration > 2 seconds over 5 minutes
- **mcp_tool_call_spike** — > 100 tool calls in 5 minutes (possible runaway agent)

Uses existing alerting engine operators. Copy to `alerts.yml` and customize thresholds.

## Test plan

- [x] 219 unit tests pass
- [x] Alert conditions use valid operators (ratio, avg, sum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)