### PR TITLE
fix(alerts): Grafana annotation 401 — fallback to Basic Auth

### DIFF
--- a/packages/instrumentation/src/alerts/grafana.ts
+++ b/packages/instrumentation/src/alerts/grafana.ts
@@ -6,7 +6,13 @@ export async function postGrafanaAnnotation(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
-  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  } else {
+    // Fall back to Basic Auth with default Grafana credentials
+    headers["Authorization"] = `Basic ${btoa("admin:admin")}`;
+  }
 
   const res = await fetch(`${grafanaUrl}/api/annotations`, {
     method: "POST",


### PR DESCRIPTION
## Summary

Closes #246, part of #231

Fix 401 Unauthorized when posting Grafana annotations without `grafanaApiKey`.

When `grafanaApiKey` is not set, fall back to Basic Auth with default Grafana credentials (`admin:admin`) — matches the default from `npx toad-eye init`.

Found during manual testing session (case 11 — alerting).

## Test plan

- [x] 219 unit tests pass
- [ ] Manual: run alerting test without grafanaApiKey, annotation should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)