### PR TITLE
feat(mcp): add tool callers metric for usage analytics

### DIFF
--- a/packages/instrumentation/src/mcp/metrics.ts
+++ b/packages/instrumentation/src/mcp/metrics.ts
@@ -23,6 +23,7 @@ let toolCalls: Counter;
 let toolErrors: Counter;
 let resourceReads: Counter;
 let sessionActive: UpDownCounter;
+let toolCallers: Counter;
 
 let initialized = false;
 
@@ -52,12 +53,18 @@ function ensureInit() {
   sessionActive = meter.createUpDownCounter(GEN_AI_METRICS.MCP_SESSION_ACTIVE, {
     description: "Number of active MCP sessions",
   });
+
+  toolCallers = meter.createCounter(GEN_AI_METRICS.MCP_TOOL_CALLERS, {
+    description:
+      "MCP tool calls by session — use count(distinct) for unique callers",
+  });
 }
 
 export function recordMcpToolCall(
   toolName: string,
   durationMs: number,
   status: "success" | "error",
+  sessionId?: string,
 ) {
   ensureInit();
   toolCalls.add(1, {
@@ -69,6 +76,12 @@ export function recordMcpToolCall(
     "gen_ai.tool.name": toolName,
     "mcp.method.name": MCP_METHODS.TOOLS_CALL,
   });
+  if (sessionId) {
+    toolCallers.add(1, {
+      "gen_ai.tool.name": toolName,
+      "mcp.session.id": sessionId,
+    });
+  }
 }
 
 export function recordMcpToolError(toolName: string, errorType: string) {

--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -195,14 +195,14 @@ export function toadEyeMiddleware(
         }
 
         endSpanSuccess(span);
-        recordMcpToolCall(name, durationMs, "success");
+        recordMcpToolCall(name, durationMs, "success", sessionId);
         return result;
       } catch (error) {
         const durationMs = performance.now() - start;
         const errorType =
           error instanceof Error ? error.constructor.name : "UnknownError";
         endSpanError(span, error);
-        recordMcpToolCall(name, durationMs, "error");
+        recordMcpToolCall(name, durationMs, "error", sessionId);
         recordMcpToolError(name, errorType);
         throw error;
       }

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -39,6 +39,7 @@ export const GEN_AI_METRICS = {
   MCP_TOOL_ERRORS: "gen_ai.mcp.tool.errors",
   MCP_RESOURCE_READS: "gen_ai.mcp.resource.reads",
   MCP_SESSION_ACTIVE: "gen_ai.mcp.session.active",
+  MCP_TOOL_CALLERS: "gen_ai.mcp.tool.callers",
 } as const;
 
 /** @deprecated Use GEN_AI_METRICS instead. Kept for backward compatibility. */


### PR DESCRIPTION
## Summary

Closes #247, part of #231

Add `gen_ai.mcp.tool.callers` counter metric with `mcp.session.id` dimension for tracking unique callers per tool.

Enables PromQL queries:
- `count by (gen_ai_tool_name) (gen_ai_mcp_tool_callers_total)` — calls per tool per session
- Unique caller count via label cardinality

Also passes `sessionId` through `recordMcpToolCall` to link tool calls to sessions.

## Test plan

- [x] 219 unit tests pass
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)