### PR TITLE
feat(grafana): add MCP Tool Analytics dashboard + cost attribution

### DIFF
--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -46,14 +46,14 @@ Open [localhost:3100](http://localhost:3100) (Grafana, admin/admin) to see your 
 
 ## What you get
 
-| Feature                   | Description                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Auto-instrumentation**  | OpenAI, Anthropic, Gemini, Vercel AI SDK — regular + streaming                              |
-| **MCP server monitoring** | One-line middleware for MCP servers — trace every tool call, resource read, prompt          |
-| **10 Grafana dashboards** | Overview, Cost, Latency, Errors, Model Comparison, FinOps, Provider Health, Agent, MCP, E2E |
-| **Cost tracking**         | Per-request USD cost, daily totals, projected monthly spend                                 |
-| **Budget guards**         | Daily/per-user/per-model spend limits — warn, block, or auto-downgrade                      |
-| **Privacy controls**      | Built-in PII redaction (email, SSN, CC, phone), hashing, content masking                    |
+| Feature                   | Description                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Auto-instrumentation**  | OpenAI, Anthropic, Gemini, Vercel AI SDK — regular + streaming                                         |
+| **MCP server monitoring** | One-line middleware for MCP servers — trace every tool call, resource read, prompt                     |
+| **11 Grafana dashboards** | Overview, Cost, Latency, Errors, Model Comparison, FinOps, Provider Health, Agent, MCP, E2E, Analytics |
+| **Cost tracking**         | Per-request USD cost, daily totals, projected monthly spend                                            |
+| **Budget guards**         | Daily/per-user/per-model spend limits — warn, block, or auto-downgrade                                 |
+| **Privacy controls**      | Built-in PII redaction (email, SSN, CC, phone), hashing, content masking                               |
 
 <details>
 <summary>Advanced features</summary>
@@ -385,20 +385,21 @@ Self-hosted mode remains the default. Cloud mode activates automatically when `a
 
 ## Grafana dashboards
 
-10 pre-built dashboards auto-provisioned on `npx toad-eye init`:
+11 pre-built dashboards auto-provisioned on `npx toad-eye init`:
 
-| Dashboard              | What it shows                                                    |
-| ---------------------- | ---------------------------------------------------------------- |
-| **Overview**           | Request rate, error rate, latency p50/p95, cost, totals          |
-| **Cost Breakdown**     | Spend by provider/model, daily trend, projected monthly          |
-| **Latency Analysis**   | p50/p95/p99 by model, distribution histogram, TTFT               |
-| **Error Drill-down**   | Error rate by provider/model, error vs success                   |
-| **Model Comparison**   | Latency vs cost vs error rate vs throughput per model            |
-| **FinOps Attribution** | Cost by team/user/feature, projected spend, what-if table        |
-| **Provider Health**    | Provider status (healthy/degraded/down), uptime, error breakdown |
-| **Agent Workflow**     | Steps per query, tool usage frequency, step type breakdown       |
-| **MCP Server**         | Tool call rate, duration p50/p95, errors by tool, resource reads |
-| **MCP End-to-End**     | LLM vs tool latency, error propagation, cost by model            |
+| Dashboard              | What it shows                                                      |
+| ---------------------- | ------------------------------------------------------------------ |
+| **Overview**           | Request rate, error rate, latency p50/p95, cost, totals            |
+| **Cost Breakdown**     | Spend by provider/model, daily trend, projected monthly            |
+| **Latency Analysis**   | p50/p95/p99 by model, distribution histogram, TTFT                 |
+| **Error Drill-down**   | Error rate by provider/model, error vs success                     |
+| **Model Comparison**   | Latency vs cost vs error rate vs throughput per model              |
+| **FinOps Attribution** | Cost by team/user/feature, projected spend, what-if table          |
+| **Provider Health**    | Provider status (healthy/degraded/down), uptime, error breakdown   |
+| **Agent Workflow**     | Steps per query, tool usage frequency, step type breakdown         |
+| **MCP Server**         | Tool call rate, duration p50/p95, errors by tool, resource reads   |
+| **MCP End-to-End**     | LLM vs tool latency, error propagation, cost by model              |
+| **MCP Tool Analytics** | Tool popularity, unique callers, cost per model, performance table |
 
 ## Subpath imports
 

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
@@ -1,0 +1,295 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Tool Popularity Ranking",
+      "description": "Most called tools by total invocations",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (gen_ai_tool_name) (increase(gen_ai_mcp_tool_calls_total[1h])))",
+          "legendFormat": "{{gen_ai_tool_name}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 10 },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10
+      }
+    },
+    {
+      "title": "Unique Callers per Tool",
+      "description": "Number of distinct sessions calling each tool",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "count by (gen_ai_tool_name) (sum by (gen_ai_tool_name, mcp_session_id) (gen_ai_mcp_tool_callers_total))",
+          "legendFormat": "{{gen_ai_tool_name}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "steps": [
+              { "color": "purple", "value": null },
+              { "color": "blue", "value": 5 },
+              { "color": "green", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10
+      }
+    },
+    {
+      "title": "Tool Usage Over Time",
+      "description": "Call rate per tool — spot trends and spikes",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_tool_name) (rate(gen_ai_mcp_tool_calls_total[5m]))",
+          "legendFormat": "{{gen_ai_tool_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "stacking": { "mode": "none" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["mean", "max", "sum"]
+        },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Cost per LLM Model (via sampling)",
+      "description": "LLM cost breakdown — visible when MCP tools call LLMs internally",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_request_model) (increase(gen_ai_client_request_cost_sum[1h]))",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value", "percent"]
+        },
+        "pieType": "donut",
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Cost Over Time",
+      "description": "LLM cost rate — attribute to tools via trace context",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_sum[5m])) * 3600",
+          "legendFormat": "{{gen_ai_request_model}} ($/hr)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum", "mean"]
+        },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Tool Performance Summary",
+      "description": "All tools: call count, avg duration, error rate, unique callers",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (gen_ai_tool_name) (increase(gen_ai_mcp_tool_calls_total[1h]))",
+          "legendFormat": "",
+          "refId": "calls",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "expr": "sum by (gen_ai_tool_name) (rate(gen_ai_mcp_tool_duration_sum[1h])) / sum by (gen_ai_tool_name) (rate(gen_ai_mcp_tool_duration_count[1h]))",
+          "legendFormat": "",
+          "refId": "avg_duration",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "expr": "sum by (gen_ai_tool_name) (increase(gen_ai_mcp_tool_errors_total[1h])) / sum by (gen_ai_tool_name) (increase(gen_ai_mcp_tool_calls_total[1h]))",
+          "legendFormat": "",
+          "refId": "error_rate",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "expr": "count by (gen_ai_tool_name) (sum by (gen_ai_tool_name, mcp_session_id) (gen_ai_mcp_tool_callers_total))",
+          "legendFormat": "",
+          "refId": "callers",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "merge" },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "gen_ai_tool_name": "Tool",
+              "Value #calls": "Calls (1h)",
+              "Value #avg_duration": "Avg Duration (ms)",
+              "Value #error_rate": "Error Rate",
+              "Value #callers": "Unique Callers"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "center" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Avg Duration (ms)" },
+            "properties": [
+              { "id": "unit", "value": "ms" },
+              { "id": "decimals", "value": 1 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Error Rate" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "decimals", "value": 2 },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 0.05 },
+                    { "color": "red", "value": 0.1 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Calls (1h)" },
+            "properties": [{ "id": "decimals", "value": 0 }]
+          }
+        ]
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["toad-eye", "mcp", "analytics", "cost"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MCP Tool Analytics",
+  "uid": "toad-eye-mcp-analytics",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Closes #248, closes #249, completes #231 (Epic 4)

New "MCP Tool Analytics" dashboard — 11th dashboard in toad-eye:

- **Tool Popularity Ranking** — bar gauge, top 10 by call count
- **Unique Callers per Tool** — distinct sessions per tool
- **Tool Usage Over Time** — rate per tool with legend table
- **Cost per LLM Model** — donut chart (visible when tools use sampling)
- **Cost Over Time** — $/hr by model
- **Tool Performance Summary** — table with calls, avg duration, error rate, unique callers

Cost attribution: PromQL queries roll up `gen_ai.client.request.cost` by model. When MCP tools call LLMs via `traceSampling()`, cost is attributed through trace context.

## Test plan

- [x] 219 unit tests pass
- [x] TypeScript build clean
- [ ] Manual: verify dashboard renders in Grafana after `npx toad-eye init --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)