### PR TITLE
fix(mcp): set span as active context in tool/resource/prompt handlers (#264)

### DIFF
--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -11,6 +11,7 @@
 
 import {
   context,
+  trace,
   diag,
   DiagConsoleLogger,
   DiagLogLevel,
@@ -183,7 +184,7 @@ export function toadEyeMiddleware(
 
       const start = performance.now();
       try {
-        const result = await context.with(context.active(), () =>
+        const result = await context.with(trace.setSpan(parentCtx, span), () =>
           originalHandler(...handlerArgs),
         );
         const durationMs = performance.now() - start;
@@ -250,7 +251,10 @@ export function toadEyeMiddleware(
         }
 
         try {
-          const result = await originalHandler(...handlerArgs);
+          const result = await context.with(
+            trace.setSpan(parentCtx, span),
+            () => originalHandler(...handlerArgs),
+          );
           endSpanSuccess(span);
           recordMcpResourceRead(uri);
           return result;
@@ -294,7 +298,10 @@ export function toadEyeMiddleware(
         });
 
         try {
-          const result = await originalHandler(...handlerArgs);
+          const result = await context.with(
+            trace.setSpan(parentCtx, span),
+            () => originalHandler(...handlerArgs),
+          );
           endSpanSuccess(span);
           return result;
         } catch (error) {


### PR DESCRIPTION
## Summary

- **Fixed `context.with(context.active(), fn)` no-op** in tool handler — span was never set as active context, breaking trace propagation for any nested OTel operations inside MCP handlers
- **Applied same fix to resource and prompt handlers** which were also missing `context.with` entirely
- All three wrappers now use `context.with(trace.setSpan(parentCtx, span), fn)` — consistent with client-side instrumentation

Closes #264

## Test plan

- [x] Build passes
- [x] 267 tests pass
- [ ] Full stack verification: tool handler calling `traceLLMCall()` produces child span under MCP tool span in Jaeger

🤖 Generated with [Claude Code](https://claude.com/claude-code)