### PR TITLE
fix(alerts): MCP metric support in alerting engine + dashboard cost panels (#265, #266)

### DIFF
--- a/packages/instrumentation/src/alerts/conditions.ts
+++ b/packages/instrumentation/src/alerts/conditions.ts
@@ -8,6 +8,12 @@ const METRIC_MAP: Record<string, string> = {
   "gen_ai.client.requests": "gen_ai_client_requests_total",
   "gen_ai.client.errors": "gen_ai_client_errors_total",
   "gen_ai.client.token.usage": "gen_ai_client_token_usage_total",
+  // MCP metrics
+  "gen_ai.mcp.tool.calls": "gen_ai_mcp_tool_calls_total",
+  "gen_ai.mcp.tool.errors": "gen_ai_mcp_tool_errors_total",
+  "gen_ai.mcp.tool.duration": "gen_ai_mcp_tool_duration",
+  "gen_ai.mcp.resource.reads": "gen_ai_mcp_resource_reads_total",
+  "gen_ai.mcp.tool.callers": "gen_ai_mcp_tool_callers_total",
   // Legacy names (backward compat)
   "llm.request.cost": "gen_ai_client_request_cost_USD_sum",
   "llm.request.duration": "gen_ai_client_operation_duration_milliseconds",
@@ -18,6 +24,10 @@ const METRIC_MAP: Record<string, string> = {
 
 function toPromMetric(metric: string): string {
   return METRIC_MAP[metric] ?? metric.replace(/\./g, "_");
+}
+
+function isMcpMetric(metric: string): boolean {
+  return metric.startsWith("gen_ai.mcp.");
 }
 
 type ConditionOperator = "sum" | "avg" | "rate" | "max" | "p95_pct" | "ratio";
@@ -96,7 +106,10 @@ function buildPromQL(
 
 function buildTopModelsQuery(metric: string, window: string): string {
   const m = toPromMetric(metric);
-  return `topk(5, sum by (gen_ai_request_model) (increase(${m}[${window}])))`;
+  const groupBy = isMcpMetric(metric)
+    ? "gen_ai_tool_name"
+    : "gen_ai_request_model";
+  return `topk(5, sum by (${groupBy}) (increase(${m}[${window}])))`;
 }
 
 function matches(
@@ -140,17 +153,20 @@ async function queryTopModels(
   const url = `${prometheusUrl}/api/v1/query?query=${encodeURIComponent(promql)}`;
   const res = await fetch(url);
   if (!res.ok) return [];
+  const labelKey = isMcpMetric(metric)
+    ? "gen_ai_tool_name"
+    : "gen_ai_request_model";
   const data = (await res.json()) as {
     data: {
       result: Array<{
-        metric: { gen_ai_request_model?: string };
+        metric: Record<string, string>;
         value: [number, string];
       }>;
     };
   };
   return data.data.result
     .map((r) => ({
-      model: r.metric.gen_ai_request_model ?? "unknown",
+      model: r.metric[labelKey] ?? "unknown",
       value: parseFloat(r.value[1]),
     }))
     .sort((a, b) => b.value - a.value);
@@ -180,15 +196,27 @@ async function evalP95Baseline(
 /** Evaluate error ratio: errors / requests over window */
 async function evalErrorRatio(
   prometheusUrl: string,
+  metric: string,
   window: string,
 ): Promise<number> {
+  let errorMetric: string;
+  let requestMetric: string;
+
+  if (isMcpMetric(metric)) {
+    errorMetric = "gen_ai_mcp_tool_errors_total";
+    requestMetric = "gen_ai_mcp_tool_calls_total";
+  } else {
+    errorMetric = "gen_ai_client_errors_total";
+    requestMetric = "gen_ai_client_requests_total";
+  }
+
   const errors = await queryScalar(
     prometheusUrl,
-    `sum(increase(gen_ai_client_errors_total[${window}]))`,
+    `sum(increase(${errorMetric}[${window}]))`,
   );
   const requests = await queryScalar(
     prometheusUrl,
-    `sum(increase(gen_ai_client_requests_total[${window}]))`,
+    `sum(increase(${requestMetric}[${window}]))`,
   );
   if (requests === 0) return 0;
   return errors / requests;
@@ -217,7 +245,7 @@ export async function evaluateCondition(
         parsed.baselineWindow!,
       );
     } else if (parsed.operator === "ratio") {
-      value = await evalErrorRatio(prometheusUrl, parsed.window);
+      value = await evalErrorRatio(prometheusUrl, rule.metric, parsed.window);
     } else {
       const promql = buildPromQL(rule.metric, parsed.operator, parsed.window);
       value = await queryScalar(prometheusUrl, promql);

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
@@ -126,7 +126,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (gen_ai_request_model) (increase(gen_ai_client_request_cost_sum[1h]))",
+          "expr": "sum by (gen_ai_request_model) (increase(gen_ai_client_request_cost_USD_sum[1h]))",
           "legendFormat": "{{gen_ai_request_model}}",
           "refId": "A",
           "instant": true
@@ -158,7 +158,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_sum[5m])) * 3600",
+          "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_USD_sum[5m])) * 3600",
           "legendFormat": "{{gen_ai_request_model}} ($/hr)",
           "refId": "A"
         }

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-e2e.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-e2e.json
@@ -276,7 +276,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_sum[5m]))",
+          "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_USD_sum[5m]))",
           "legendFormat": "{{gen_ai_request_model}}",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary

- **Fixed `evalErrorRatio`** — was hardcoded to `gen_ai_client_errors_total / gen_ai_client_requests_total`, now derives correct error/request metric pair based on `rule.metric` (LLM vs MCP)
- **Added MCP metrics to `METRIC_MAP`** — `gen_ai.mcp.tool.calls`, `.errors`, `.duration`, `.resource.reads`, `.tool.callers` now resolve to correct Prometheus names with proper `_total` suffixes
- **Fixed `buildTopModelsQuery`** — groups by `gen_ai_tool_name` for MCP metrics instead of `gen_ai_request_model`
- **Fixed `queryTopModels`** response parsing — extracts correct label key based on metric type
- **Fixed cost panels** in `mcp-analytics.json` and `mcp-e2e.json` — `gen_ai_client_request_cost_sum` → `gen_ai_client_request_cost_USD_sum`

Closes #265, closes #266

## Test plan

- [x] Build passes
- [x] 267 tests pass
- [x] Full stack: configure MCP alert rule, verify it queries correct MCP metrics in Prometheus
- [x] Grafana: verify cost panels in MCP Analytics and MCP E2E dashboards show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)