### PR TITLE
fix(mcp): session lifecycle + deep redaction (#267, #268)

### DIFF
--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -21,6 +21,7 @@ import {
   enableMcpClientInstrumentation,
   disableMcpClientInstrumentation,
 } from "../mcp/client.js";
+import { resetMcpMetrics } from "../mcp/metrics.js";
 import { BudgetTracker } from "../budget/index.js";
 import { ToadEyeAISpanProcessor } from "../vercel.js";
 import type { LLMProvider } from "../types/index.js";
@@ -223,5 +224,6 @@ export async function shutdown() {
   currentConfig = null;
   budgetTracker = null;
   resetMetrics();
+  resetMcpMetrics();
   resetCustomPricing();
 }

--- a/packages/instrumentation/src/mcp/index.ts
+++ b/packages/instrumentation/src/mcp/index.ts
@@ -1,5 +1,8 @@
 export { toadEyeMiddleware, traceSampling } from "./middleware.js";
-export type { TraceSamplingOptions } from "./middleware.js";
+export type {
+  TraceSamplingOptions,
+  ToadEyeMiddlewareDispose,
+} from "./middleware.js";
 export type { ToadMcpOptions, McpSpanAttributes } from "./types.js";
 export { MCP_METHODS } from "./spans.js";
 export {

--- a/packages/instrumentation/src/mcp/metrics.ts
+++ b/packages/instrumentation/src/mcp/metrics.ts
@@ -110,3 +110,8 @@ export function recordMcpSessionEnd() {
   ensureInit();
   sessionActive.add(-1);
 }
+
+/** Reset MCP metrics state — must be called from shutdown() alongside resetMetrics(). */
+export function resetMcpMetrics() {
+  initialized = false;
+}

--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -32,6 +32,7 @@ import {
   recordMcpToolError,
   recordMcpResourceRead,
   recordMcpSessionStart,
+  recordMcpSessionEnd,
 } from "./metrics.js";
 
 const DEFAULT_MAX_PAYLOAD_SIZE = 4096;
@@ -61,7 +62,13 @@ function redactObject(
   if (typeof obj !== "object" || obj === null) return {};
   const result: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-    result[k] = keys.includes(k) ? "[REDACTED]" : v;
+    if (keys.includes(k)) {
+      result[k] = "[REDACTED]";
+    } else if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+      result[k] = redactObject(v, keys);
+    } else {
+      result[k] = v;
+    }
   }
   return result;
 }
@@ -103,11 +110,16 @@ function ensureStdioSafe() {
   diag.setLogger(safeLogger, DiagLogLevel.WARN);
 }
 
+export interface ToadEyeMiddlewareDispose {
+  /** Call when the MCP server is shutting down to decrement the active session counter. */
+  (): void;
+}
+
 export function toadEyeMiddleware(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server: any,
   options: ToadMcpOptions = {},
-) {
+): ToadEyeMiddlewareDispose {
   ensureStdioSafe();
   recordMcpSessionStart();
   const serverName: string = server.name ?? server._name ?? "mcp-server";
@@ -313,6 +325,13 @@ export function toadEyeMiddleware(
       return originalPrompt(name, ...rest);
     };
   }
+
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    recordMcpSessionEnd();
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`toadEyeMiddleware` now returns a dispose callback** — call it on server shutdown to decrement `gen_ai.mcp.session.active` counter. Dispose is idempotent (safe to call multiple times)
- **Added `resetMcpMetrics()`** — called from `shutdown()` alongside `resetMetrics()` to prevent stale metric references after SDK re-initialization
- **`redactObject` now recurses into nested objects** — `{ config: { apiKey: "sk-..." } }` with `redactKeys: ["apiKey"]` now correctly redacts the nested key

Closes #267, closes #268

## API change

```ts
// Before (void return)
toadEyeMiddleware(server);

// After (returns dispose callback)
const dispose = toadEyeMiddleware(server);
// On shutdown:
dispose();
```

Return type is backward-compatible — existing code that ignores the return value continues to work.

## Test plan

- [x] Build passes
- [x] 267 tests pass
- [ ] Verify session counter decrements after calling dispose()
- [ ] Verify nested redaction: `{ config: { apiKey: "sk-..." } }` → `{ config: { apiKey: "[REDACTED]" } }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)