### PR TITLE
test(mcp): improve test coverage — span attrs, context, redaction, sampling (#271)

### DIFF
--- a/packages/instrumentation/src/__tests__/mcp/context.test.ts
+++ b/packages/instrumentation/src/__tests__/mcp/context.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { extractContextFromMeta } from "../../mcp/context.js";
-import { context } from "@opentelemetry/api";
+import { context, trace } from "@opentelemetry/api";
+import { setupOTelForTests } from "./test-utils.js";
 
 describe("extractContextFromMeta", () => {
+  setupOTelForTests();
+
   it("returns active context when meta is undefined", () => {
     const ctx = extractContextFromMeta(undefined);
     expect(ctx).toBe(context.active());
@@ -13,19 +16,24 @@ describe("extractContextFromMeta", () => {
     expect(ctx).toBe(context.active());
   });
 
-  it("returns a context when traceparent is present", () => {
+  it("extracts correct traceId and spanId from traceparent", () => {
     const ctx = extractContextFromMeta({
       traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     });
-    // Should not be the default empty context — propagation extracted something
-    expect(ctx).toBeDefined();
+    const spanCtx = trace.getSpanContext(ctx);
+    expect(spanCtx).toBeDefined();
+    expect(spanCtx!.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(spanCtx!.spanId).toBe("00f067aa0ba902b7");
+    expect(spanCtx!.traceFlags).toBe(1); // sampled
   });
 
-  it("handles traceparent with tracestate", () => {
+  it("extracts traceparent with tracestate", () => {
     const ctx = extractContextFromMeta({
       traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
       tracestate: "vendor=value",
     });
-    expect(ctx).toBeDefined();
+    const spanCtx = trace.getSpanContext(ctx);
+    expect(spanCtx).toBeDefined();
+    expect(spanCtx!.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
   });
 });

--- a/packages/instrumentation/src/__tests__/mcp/middleware.test.ts
+++ b/packages/instrumentation/src/__tests__/mcp/middleware.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { SpanKind } from "@opentelemetry/api";
 import { toadEyeMiddleware, traceSampling } from "../../mcp/index.js";
+import {
+  setupOTelForTests,
+  findSpan,
+  getSpanAttr,
+  getSpans,
+  SpanStatusCode,
+} from "./test-utils.js";
 
 function createMockServer() {
   const tools: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
@@ -28,133 +36,207 @@ function createMockServer() {
       ) => Promise<unknown>;
       prompts[name] = handler;
     },
-    // Test helpers
     _callTool: (name: string, args: unknown) => tools[name]!(args),
     _callResource: (name: string, args: unknown) => resources[name]!(args),
     _callPrompt: (name: string, args: unknown) => prompts[name]!(args),
   };
 }
 
+// Setup OTel once for the entire file
+setupOTelForTests();
+
 describe("toadEyeMiddleware", () => {
-  it("wraps tool handlers without breaking registration", async () => {
+  it("creates a SERVER span with correct attributes for tool calls", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server);
 
-    const handler = vi.fn(async () => ({
-      content: [{ type: "text", text: "result" }],
+    server.tool("calculate", async () => ({
+      content: [{ type: "text", text: "4" }],
     }));
 
-    server.tool("calculate", handler);
+    await server._callTool("calculate", { expression: "2+2" });
 
-    const result = await server._callTool("calculate", {
-      expression: "2+2",
-    });
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({
-      content: [{ type: "text", text: "result" }],
-    });
+    const span = findSpan("tools/call calculate");
+    expect(span).toBeDefined();
+    expect(span!.kind).toBe(SpanKind.SERVER);
+    expect(getSpanAttr(span!, "gen_ai.operation.name")).toBe("tools/call");
+    expect(getSpanAttr(span!, "mcp.method.name")).toBe("tools/call");
+    expect(getSpanAttr(span!, "gen_ai.tool.name")).toBe("calculate");
+    expect(getSpanAttr(span!, "mcp.server.name")).toBe("test-server");
+    expect(span!.status.code).toBe(SpanStatusCode.OK);
   });
 
-  it("wraps resource handlers", async () => {
+  it("creates a SERVER span for resource reads", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server);
 
-    const handler = vi.fn(async () => ({
+    server.resource("docs", async () => ({
       contents: [{ uri: "file:///test", text: "content" }],
     }));
 
-    server.resource("docs", handler);
+    await server._callResource("docs", { uri: "file:///test" });
 
-    const result = await server._callResource("docs", {
-      uri: "file:///test",
-    });
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({
-      contents: [{ uri: "file:///test", text: "content" }],
-    });
+    const span = findSpan("resources/read");
+    expect(span).toBeDefined();
+    expect(span!.kind).toBe(SpanKind.SERVER);
+    expect(getSpanAttr(span!, "gen_ai.operation.name")).toBe("resources/read");
   });
 
-  it("wraps prompt handlers", async () => {
+  it("creates a SERVER span for prompt gets", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server);
 
-    const handler = vi.fn(async () => ({
-      messages: [{ role: "user", content: { type: "text", text: "hello" } }],
+    server.prompt("greeting", async () => ({
+      messages: [{ role: "user", content: { type: "text", text: "hi" } }],
     }));
 
-    server.prompt("greeting", handler);
+    await server._callPrompt("greeting", {});
 
-    const result = await server._callPrompt("greeting", {});
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(result).toBeDefined();
+    const span = findSpan("prompts/get greeting");
+    expect(span).toBeDefined();
+    expect(span!.kind).toBe(SpanKind.SERVER);
+    expect(getSpanAttr(span!, "gen_ai.operation.name")).toBe("prompts/get");
   });
 
   it("does NOT record arguments by default (privacy)", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server);
 
-    const handler = vi.fn(async () => ({
+    server.tool("secret-tool", async () => ({
       content: [{ type: "text", text: "ok" }],
     }));
 
-    server.tool("secret-tool", handler);
     await server._callTool("secret-tool", {
       apiKey: "sk-secret",
       query: "test",
     });
 
-    // Handler was called — middleware didn't break it
-    expect(handler).toHaveBeenCalledTimes(1);
+    const span = findSpan("tools/call secret-tool");
+    expect(span).toBeDefined();
+    expect(span!.attributes["gen_ai.tool.call.arguments"]).toBeUndefined();
   });
 
   it("records arguments when recordInputs: true", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server, { recordInputs: true });
 
-    const handler = vi.fn(async () => ({
+    server.tool("open-tool", async () => ({
       content: [{ type: "text", text: "ok" }],
     }));
 
-    server.tool("open-tool", handler);
     await server._callTool("open-tool", { query: "test" });
 
-    expect(handler).toHaveBeenCalledTimes(1);
+    const span = findSpan("tools/call open-tool");
+    expect(span).toBeDefined();
+    const args = span!.attributes["gen_ai.tool.call.arguments"] as string;
+    expect(args).toBeDefined();
+    expect(JSON.parse(args)).toMatchObject({ query: "test" });
   });
 
-  it("redacts specified keys from arguments", async () => {
+  it("redacts specified keys from arguments (top-level)", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server, {
       recordInputs: true,
       redactKeys: ["apiKey", "token"],
     });
 
-    const handler = vi.fn(async () => ({
+    server.tool("redact-tool", async () => ({
       content: [{ type: "text", text: "ok" }],
     }));
 
-    server.tool("redact-tool", handler);
     await server._callTool("redact-tool", {
       apiKey: "sk-secret",
       token: "tok-123",
       query: "visible",
     });
 
-    expect(handler).toHaveBeenCalledTimes(1);
+    const span = findSpan("tools/call redact-tool");
+    const args = JSON.parse(
+      span!.attributes["gen_ai.tool.call.arguments"] as string,
+    );
+    expect(args.apiKey).toBe("[REDACTED]");
+    expect(args.token).toBe("[REDACTED]");
+    expect(args.query).toBe("visible");
   });
 
-  it("propagates errors from handlers", async () => {
+  it("redacts nested keys recursively", async () => {
+    const server = createMockServer();
+    toadEyeMiddleware(server, {
+      recordInputs: true,
+      redactKeys: ["apiKey"],
+    });
+
+    server.tool("nested-tool", async () => ({
+      content: [{ type: "text", text: "ok" }],
+    }));
+
+    await server._callTool("nested-tool", {
+      config: {
+        apiKey: "sk-nested-secret",
+        endpoint: "https://api.example.com",
+      },
+      query: "test",
+    });
+
+    const span = findSpan("tools/call nested-tool");
+    const args = JSON.parse(
+      span!.attributes["gen_ai.tool.call.arguments"] as string,
+    );
+    expect(args.config.apiKey).toBe("[REDACTED]");
+    expect(args.config.endpoint).toBe("https://api.example.com");
+    expect(args.query).toBe("test");
+  });
+
+  it("records outputs when recordOutputs: true", async () => {
+    const server = createMockServer();
+    toadEyeMiddleware(server, { recordOutputs: true });
+
+    server.tool("output-tool", async () => ({
+      content: [{ type: "text", text: "the result" }],
+    }));
+
+    await server._callTool("output-tool", {});
+
+    const span = findSpan("tools/call output-tool");
+    expect(span).toBeDefined();
+    const result = span!.attributes["gen_ai.tool.call.result"] as string;
+    expect(result).toBeDefined();
+    expect(JSON.parse(result)).toMatchObject({
+      content: [{ type: "text", text: "the result" }],
+    });
+  });
+
+  it("does NOT record outputs by default", async () => {
     const server = createMockServer();
     toadEyeMiddleware(server);
 
-    const handler = vi.fn(async () => {
-      throw new Error("Tool failed");
+    server.tool("no-output", async () => ({
+      content: [{ type: "text", text: "hidden" }],
+    }));
+
+    await server._callTool("no-output", {});
+
+    const span = findSpan("tools/call no-output");
+    expect(span!.attributes["gen_ai.tool.call.result"]).toBeUndefined();
+  });
+
+  it("sets ERROR status and error.type on handler failure", async () => {
+    const server = createMockServer();
+    toadEyeMiddleware(server);
+
+    server.tool("failing-tool", async () => {
+      throw new TypeError("invalid input");
     });
 
-    server.tool("failing-tool", handler);
-
     await expect(server._callTool("failing-tool", {})).rejects.toThrow(
-      "Tool failed",
+      "invalid input",
     );
+
+    const span = findSpan("tools/call failing-tool");
+    expect(span).toBeDefined();
+    expect(span!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span!.status.message).toBe("invalid input");
+    expect(getSpanAttr(span!, "error.type")).toBe("TypeError");
   });
 
   it("calls onToolCall hook with span", async () => {
@@ -170,32 +252,59 @@ describe("toadEyeMiddleware", () => {
 
     expect(onToolCall).toHaveBeenCalledTimes(1);
     expect(onToolCall).toHaveBeenCalledWith(
-      expect.anything(), // span
+      expect.anything(),
       "hooked-tool",
       expect.objectContaining({ data: "test" }),
     );
   });
+
+  it("returns a dispose callback that is idempotent", () => {
+    const server = createMockServer();
+    const dispose = toadEyeMiddleware(server);
+    expect(typeof dispose).toBe("function");
+    // Should not throw when called multiple times
+    dispose();
+    dispose();
+  });
 });
 
 describe("traceSampling", () => {
-  it("wraps async function and returns its result", async () => {
-    const mockResponse = {
-      model: "gpt-4",
-      role: "assistant",
-      content: { type: "text", text: "Summary result" },
-    };
+  it("creates a CLIENT span with model attribute", async () => {
+    const result = await traceSampling(
+      async () => ({ model: "gpt-4", content: "hello" }),
+      { model: "gpt-4", serverName: "test", serverVersion: "1.0.0" },
+    );
 
-    const result = await traceSampling(async () => mockResponse, {
-      model: "gpt-4",
-      maxTokens: 500,
-      serverName: "test-server",
-      serverVersion: "1.0.0",
-    });
+    expect(result).toEqual({ model: "gpt-4", content: "hello" });
 
-    expect(result).toEqual(mockResponse);
+    const span = findSpan("sampling/createMessage gpt-4");
+    expect(span).toBeDefined();
+    expect(span!.kind).toBe(SpanKind.CLIENT);
+    expect(getSpanAttr(span!, "gen_ai.request.model")).toBe("gpt-4");
+    expect(getSpanAttr(span!, "gen_ai.operation.name")).toBe(
+      "sampling/createMessage",
+    );
   });
 
-  it("propagates errors from the sampling call", async () => {
+  it("records maxTokens attribute when provided", async () => {
+    await traceSampling(async () => ({}), {
+      model: "gpt-4",
+      maxTokens: 500,
+    });
+
+    const span = findSpan("sampling/createMessage");
+    expect(span).toBeDefined();
+    expect(getSpanAttr(span!, "gen_ai.request.max_tokens")).toBe(500);
+  });
+
+  it("does NOT set maxTokens when omitted", async () => {
+    await traceSampling(async () => ({}), { model: "gpt-4" });
+
+    const span = findSpan("sampling/createMessage");
+    expect(span!.attributes["gen_ai.request.max_tokens"]).toBeUndefined();
+  });
+
+  it("sets ERROR status on failure", async () => {
     await expect(
       traceSampling(
         async () => {
@@ -204,10 +313,18 @@ describe("traceSampling", () => {
         { model: "gpt-4" },
       ),
     ).rejects.toThrow("Sampling failed");
+
+    const span = findSpan("sampling/createMessage");
+    expect(span!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(getSpanAttr(span!, "error.type")).toBe("Error");
   });
 
-  it("works with default options", async () => {
-    const result = await traceSampling(async () => ({ done: true }), {});
-    expect(result).toEqual({ done: true });
+  it("records response model when present in result", async () => {
+    await traceSampling(async () => ({ model: "gpt-4-turbo" }), {
+      model: "gpt-4",
+    });
+
+    const span = findSpan("sampling/createMessage");
+    expect(getSpanAttr(span!, "gen_ai.response.model")).toBe("gpt-4-turbo");
   });
 });

--- a/packages/instrumentation/src/__tests__/mcp/test-utils.ts
+++ b/packages/instrumentation/src/__tests__/mcp/test-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared OTel test utilities for MCP tests.
+ *
+ * Registers an in-memory span exporter so tests can capture and assert
+ * on actual span attributes, status, and kind.
+ */
+
+import { trace, propagation, SpanStatusCode } from "@opentelemetry/api";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { afterEach, beforeAll, afterAll } from "vitest";
+
+export const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+
+export function setupOTelForTests() {
+  beforeAll(() => {
+    trace.setGlobalTracerProvider(provider);
+    propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  });
+
+  afterEach(() => {
+    exporter.reset();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+    trace.disable();
+    propagation.disable();
+  });
+}
+
+export function getSpans(): ReadableSpan[] {
+  return exporter.getFinishedSpans();
+}
+
+export function findSpan(namePart: string): ReadableSpan | undefined {
+  return getSpans().find((s) => s.name.includes(namePart));
+}
+
+export function getSpanAttr(
+  span: ReadableSpan,
+  key: string,
+): string | number | boolean | undefined {
+  return span.attributes[key] as string | number | boolean | undefined;
+}
+
+export { SpanStatusCode };


### PR DESCRIPTION
## Summary

- **Added `test-utils.ts`** — shared OTel test infrastructure using `InMemorySpanExporter` + `BasicTracerProvider` so tests can capture and assert on actual span attributes
- **Rewrote middleware tests** to verify span attributes, not just handler invocation counts. Tests now assert on `gen_ai.operation.name`, `mcp.method.name`, `gen_ai.tool.name`, SpanKind, SpanStatus, etc.
- **Added new test cases:**
  - Privacy: verify `gen_ai.tool.call.arguments` is NOT set by default
  - `recordInputs`: verify arguments are serialized to span attribute
  - `recordOutputs`: verify result is serialized to span attribute
  - Nested redaction: `{ config: { apiKey: "sk-..." } }` → `[REDACTED]`
  - Error handling: verify `SpanStatusCode.ERROR` + `error.type` attribute
  - `traceSampling`: `maxTokens` attr presence/absence, response model
  - Context extraction: verify traceId/spanId from traceparent (was `toBeDefined()` no-op)
  - Dispose callback idempotency

**Test count: 267 → 273** (+6 new, existing tests now actually verify their claims)

Closes #271

## Test plan

- [x] Build passes
- [x] 273 tests pass
- [x] All new tests verify actual span attributes via InMemorySpanExporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)