### PR TITLE
feat: add onSpanEnd callback for eval integration hooks (#201)

### DIFF
--- a/packages/instrumentation/src/__tests__/span-end-processor.test.ts
+++ b/packages/instrumentation/src/__tests__/span-end-processor.test.ts
@@ -1,0 +1,134 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from "vitest";
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import {
+  ToadEyeSpanEndProcessor,
+  type SpanEndData,
+} from "../core/span-end-processor.js";
+
+const exporter = new InMemorySpanExporter();
+const collected: SpanEndData[] = [];
+const callback = vi.fn((data: SpanEndData) => {
+  collected.push(data);
+});
+
+const processor = new ToadEyeSpanEndProcessor(callback);
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter), processor],
+});
+
+beforeAll(() => {
+  trace.setGlobalTracerProvider(provider);
+});
+
+afterEach(() => {
+  exporter.reset();
+  collected.length = 0;
+  callback.mockClear();
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+  trace.disable();
+});
+
+describe("ToadEyeSpanEndProcessor", () => {
+  it("calls callback with structured span data", () => {
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("test-span");
+    span.setAttribute("gen_ai.request.model", "gpt-4o");
+    span.setAttribute("gen_ai.usage.input_tokens", 100);
+    span.setStatus({ code: SpanStatusCode.OK });
+    span.end();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    const data = collected[0]!;
+    expect(data.name).toBe("test-span");
+    expect(data.status).toBe("ok");
+    expect(data.attributes["gen_ai.request.model"]).toBe("gpt-4o");
+    expect(data.attributes["gen_ai.usage.input_tokens"]).toBe(100);
+    expect(data.traceId).toHaveLength(32);
+    expect(data.spanId).toHaveLength(16);
+    expect(data.durationMs).toBeGreaterThanOrEqual(0);
+    expect(data.kind).toBe("internal");
+    expect(data.startTime).toBeInstanceOf(Date);
+    expect(data.endTime).toBeInstanceOf(Date);
+  });
+
+  it("reports error status and message", () => {
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("error-span");
+    span.setStatus({ code: SpanStatusCode.ERROR, message: "boom" });
+    span.end();
+
+    const data = collected[0]!;
+    expect(data.status).toBe("error");
+    expect(data.error).toBe("boom");
+  });
+
+  it("reports unset status when no status is set", () => {
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("unset-span");
+    span.end();
+
+    const data = collected[0]!;
+    expect(data.status).toBe("unset");
+    expect(data.error).toBeUndefined();
+  });
+
+  it("does not throw on sync callback error", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failingProcessor = new ToadEyeSpanEndProcessor(() => {
+      throw new Error("sync fail");
+    });
+
+    // Call onEnd directly — no need for a full provider
+    const span = exporter.getFinishedSpans()[0];
+    // Create a real span to pass
+    const tracer = trace.getTracer("test");
+    const testSpan = tracer.startSpan("direct-test");
+    testSpan.end();
+    const finishedSpan = exporter.getFinishedSpans()[0]!;
+
+    failingProcessor.onEnd(finishedSpan);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("onSpanEnd callback failed"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not throw on async callback error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failingProcessor = new ToadEyeSpanEndProcessor(async () => {
+      throw new Error("async fail");
+    });
+
+    const tracer = trace.getTracer("test");
+    const testSpan = tracer.startSpan("async-test");
+    testSpan.end();
+    const finishedSpan = exporter.getFinishedSpans()[0]!;
+
+    failingProcessor.onEnd(finishedSpan);
+
+    // Wait for async rejection to be caught
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("onSpanEnd callback failed"),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/instrumentation/src/__tests__/tracer.test.ts
+++ b/packages/instrumentation/src/__tests__/tracer.test.ts
@@ -22,11 +22,15 @@ vi.mock("@opentelemetry/sdk-metrics", () => ({
 vi.mock("@opentelemetry/semantic-conventions", () => ({
   ATTR_SERVICE_NAME: "service.name",
 }));
-vi.mock("@opentelemetry/api", () => ({
-  metrics: { getMeter: () => ({}) },
-  diag: { warn: vi.fn(), debug: vi.fn() },
-  trace: { getTracer: () => ({}) },
-}));
+vi.mock("@opentelemetry/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@opentelemetry/api")>();
+  return {
+    ...actual,
+    metrics: { getMeter: () => ({}) },
+    diag: { warn: vi.fn(), debug: vi.fn() },
+    trace: { getTracer: () => ({}) },
+  };
+});
 vi.mock("../core/metrics.js", () => ({
   initMetrics: vi.fn(),
   resetMetrics: vi.fn(),

--- a/packages/instrumentation/src/core/span-end-processor.ts
+++ b/packages/instrumentation/src/core/span-end-processor.ts
@@ -1,0 +1,123 @@
+/**
+ * SpanProcessor that calls user's onSpanEnd callback with structured span data.
+ *
+ * Extracts LLM/MCP-relevant attributes from ReadableSpan into a clean
+ * SpanEndData object — user never touches OTel SDK internals.
+ */
+
+import type {
+  SpanProcessor,
+  ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+
+/** Structured span data passed to the onSpanEnd callback. */
+export interface SpanEndData {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId: string | undefined;
+  readonly name: string;
+  readonly kind: "client" | "server" | "internal" | "producer" | "consumer";
+  readonly status: "ok" | "error" | "unset";
+  readonly durationMs: number;
+  readonly startTime: Date;
+  readonly endTime: Date;
+  readonly attributes: Readonly<Record<string, string | number | boolean>>;
+  readonly error: string | undefined;
+}
+
+const SPAN_KIND_MAP: Record<number, SpanEndData["kind"]> = {
+  [SpanKind.CLIENT]: "client",
+  [SpanKind.SERVER]: "server",
+  [SpanKind.INTERNAL]: "internal",
+  [SpanKind.PRODUCER]: "producer",
+  [SpanKind.CONSUMER]: "consumer",
+};
+
+function hrtimeToDate(hrtime: [number, number]): Date {
+  return new Date(hrtime[0] * 1000 + hrtime[1] / 1_000_000);
+}
+
+function hrtimeDurationMs(
+  start: [number, number],
+  end: [number, number],
+): number {
+  return (end[0] - start[0]) * 1000 + (end[1] - start[1]) / 1_000_000;
+}
+
+function flattenAttributes(
+  attrs: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+  const result: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function toSpanEndData(span: ReadableSpan): SpanEndData {
+  const ctx = span.spanContext();
+  return {
+    traceId: ctx.traceId,
+    spanId: ctx.spanId,
+    parentSpanId:
+      (span as unknown as { parentSpanId?: string }).parentSpanId || undefined,
+    name: span.name,
+    kind: SPAN_KIND_MAP[span.kind] ?? "internal",
+    status:
+      span.status.code === SpanStatusCode.ERROR
+        ? "error"
+        : span.status.code === SpanStatusCode.OK
+          ? "ok"
+          : "unset",
+    durationMs: hrtimeDurationMs(span.startTime, span.endTime),
+    startTime: hrtimeToDate(span.startTime),
+    endTime: hrtimeToDate(span.endTime),
+    attributes: flattenAttributes(span.attributes as Record<string, unknown>),
+    error: span.status.message || undefined,
+  };
+}
+
+export type OnSpanEndCallback = (data: SpanEndData) => void | Promise<void>;
+
+export class ToadEyeSpanEndProcessor implements SpanProcessor {
+  private readonly callback: OnSpanEndCallback;
+
+  constructor(callback: OnSpanEndCallback) {
+    this.callback = callback;
+  }
+
+  onStart() {}
+
+  onEnd(span: ReadableSpan) {
+    try {
+      const result = this.callback(toSpanEndData(span));
+      // If callback returns a promise, don't block — fire and forget
+      if (result instanceof Promise) {
+        result.catch((err) => {
+          console.warn(
+            `toad-eye: onSpanEnd callback failed: ${err instanceof Error ? err.message : err}`,
+          );
+        });
+      }
+    } catch (err) {
+      console.warn(
+        `toad-eye: onSpanEnd callback failed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -24,6 +24,7 @@ import {
 import { resetMcpMetrics } from "../mcp/metrics.js";
 import { BudgetTracker } from "../budget/index.js";
 import { ToadEyeAISpanProcessor } from "../vercel.js";
+import { ToadEyeSpanEndProcessor } from "./span-end-processor.js";
 import type { LLMProvider } from "../types/index.js";
 
 const DEFAULT_ENDPOINT = "http://localhost:4318";
@@ -118,11 +119,22 @@ export function initObservability(config: ToadEyeConfig) {
     exportIntervalMillis: isCloudMode ? 10_000 : 5_000,
   });
 
-  // When custom SpanProcessors are needed (e.g., Vercel AI SDK),
+  // When custom SpanProcessors are needed (e.g., Vercel AI SDK, onSpanEnd),
   // we must also include a BatchSpanProcessor for trace export —
   // NodeSDK won't create one automatically when spanProcessors is provided.
-  const spanProcessors = config.instrument?.includes("ai")
-    ? [new BatchSpanProcessor(traceExporter), new ToadEyeAISpanProcessor()]
+  const needsCustomProcessors =
+    config.instrument?.includes("ai") || config.onSpanEnd !== undefined;
+
+  const spanProcessors = needsCustomProcessors
+    ? [
+        new BatchSpanProcessor(traceExporter),
+        ...(config.instrument?.includes("ai")
+          ? [new ToadEyeAISpanProcessor()]
+          : []),
+        ...(config.onSpanEnd !== undefined
+          ? [new ToadEyeSpanEndProcessor(config.onSpanEnd)]
+          : []),
+      ]
     : [];
 
   // SDK-side head sampling (default: 1.0 = send everything to Collector)

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -69,3 +69,7 @@ export { LLM_METRICS } from "./types/index.js";
 /** @deprecated Use GEN_AI_ATTRS instead */
 export { LLM_ATTRS } from "./types/index.js";
 export { ToadEyeAISpanProcessor, withToadEye } from "./vercel.js";
+export type {
+  SpanEndData,
+  OnSpanEndCallback,
+} from "./core/span-end-processor.js";

--- a/packages/instrumentation/src/types/config.ts
+++ b/packages/instrumentation/src/types/config.ts
@@ -4,6 +4,7 @@ import type {
   BudgetExceededMode,
   DowngradeCallback,
 } from "../budget/types.js";
+import type { OnSpanEndCallback } from "../core/span-end-processor.js";
 
 /** Sampling configuration. Tail sampling runs in OTel Collector, SDK sends all spans. */
 export interface SamplingConfig {
@@ -86,4 +87,8 @@ export interface ToadEyeConfig {
   readonly sessionId?: string | undefined;
   /** Dynamic session ID extractor — called per traceLLMCall to resolve session ID. */
   readonly sessionExtractor?: (() => string | undefined) | undefined;
+
+  // Eval hooks
+  /** Callback invoked when any span ends. Receives structured span data for eval pipelines. */
+  readonly onSpanEnd?: OnSpanEndCallback | undefined;
 }

--- a/packages/instrumentation/src/types/index.ts
+++ b/packages/instrumentation/src/types/index.ts
@@ -13,6 +13,10 @@ export const INSTRUMENTATION_NAME = "toad-eye";
 
 export type { LLMProvider, InstrumentTarget } from "./providers.js";
 export type { ToadEyeConfig, SamplingConfig } from "./config.js";
+export type {
+  SpanEndData,
+  OnSpanEndCallback,
+} from "../core/span-end-processor.js";
 export { GEN_AI_ATTRS, LLM_ATTRS } from "./attributes.js";
 export { GEN_AI_METRICS, LLM_METRICS } from "./metrics.js";
 export type { MetricName } from "./metrics.js";


### PR DESCRIPTION
## Summary

- New config option `onSpanEnd` — called with structured `SpanEndData` when any span completes
- Bridges toad-eye to eval frameworks (toad-eval, custom scorers) without touching OTel internals
- Custom `ToadEyeSpanEndProcessor` extracts clean data from ReadableSpan
- Callback errors (sync and async) are caught and logged, never crash the app
- Exported types: `SpanEndData`, `OnSpanEndCallback`

```typescript
initObservability({
  serviceName: "my-app",
  onSpanEnd: async (spanData) => {
    const score = await evalFramework.score(spanData);
    recordMetric("eval.score", score);
  },
});
```

Closes #201

## Test plan

- [x] Build passes
- [x] 278 tests pass (5 new for SpanEndProcessor)
- [x] Sync callback errors caught gracefully
- [x] Async callback errors caught gracefully
- [x] Existing tracer.test.ts mock fixed for new import chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)