### PR TITLE
chore: release v2.9.0 — onSpanEnd eval hooks

### DIFF
--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toad-eye",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Observability for MCP servers and LLM applications — traces, metrics, dashboards. One-line instrumentation for OpenAI, Anthropic, Gemini, and MCP. Self-hosted with Grafana + Prometheus + Jaeger.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump `2.8.0` → `2.9.0`

## What's new in v2.9.0

- `onSpanEnd` callback (#201) — bridges toad-eye to eval frameworks. Every completed span triggers a callback with structured `SpanEndData`.

## Test plan

- [x] Build passes
- [x] 278 tests pass
- [ ] After merge: `cd packages/instrumentation && npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)