### PR TITLE
chore: release v2.9.1 — fix npm README, update test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ Full metrics and span attribute reference: [COMPATIBILITY.md](packages/instrumen
 
 ## Tech Stack
 
-TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (273+ tests)
+TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (278+ tests)

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -169,4 +169,4 @@ Full metrics and span attribute reference: [COMPATIBILITY.md](https://github.com
 
 ## Tech Stack
 
-TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (273+ tests)
+TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (278+ tests)

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toad-eye",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Observability for MCP servers and LLM applications — traces, metrics, dashboards. One-line instrumentation for OpenAI, Anthropic, Gemini, and MCP. Self-hosted with Grafana + Prometheus + Jaeger.",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepublishOnly": "test -s README.md || { echo '❌ README.md is missing or empty'; exit 1; } && npm run build"
+    "prepublishOnly": "grep -q 'toad-eye' README.md || { echo '❌ README.md is missing or broken'; exit 1; } && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump `2.9.0` → `2.9.1`
- Fix npm showing "This package does not have a README"
- Stronger `prepublishOnly` check: `grep 'toad-eye' README.md` instead of just `test -s`
- Update test count 273 → 278 in both READMEs

## Publish

After merge:
```bash
cd packages/instrumentation && npm publish
```

Verify: `npm pack --dry-run` shows `README.md 6.3kB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)