### PR TITLE
fix(mcp): client instrumentation works in ESM projects

### DIFF
--- a/demo/src/mcp-e2e/index.ts
+++ b/demo/src/mcp-e2e/index.ts
@@ -28,8 +28,8 @@ initObservability({
   endpoint: process.env["OTEL_EXPORTER_ENDPOINT"] ?? "http://localhost:4318",
 });
 
-// Enable client-side instrumentation (patches Client.prototype)
-enableMcpClientInstrumentation();
+// Enable client-side instrumentation (pass Client class for ESM compatibility)
+enableMcpClientInstrumentation(Client);
 
 // --- Create MCP Server with tools ---
 

--- a/packages/instrumentation/src/mcp/client.ts
+++ b/packages/instrumentation/src/mcp/client.ts
@@ -50,17 +50,33 @@ function injectTraceContext(
   return params;
 }
 
-export function enableMcpClientInstrumentation(): boolean {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveClientClass(): any {
+  // Try CJS first (works when consumer uses require)
   try {
-    require.resolve("@modelcontextprotocol/sdk/client/index.js");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const sdk = require("@modelcontextprotocol/sdk/client/index.js");
+    return sdk.Client ?? sdk.default?.Client;
   } catch {
-    return false;
+    // CJS failed — will try ESM in async path
+    return null;
   }
+}
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const sdk = require("@modelcontextprotocol/sdk/client/index.js");
-  const Client = sdk.Client ?? sdk.default?.Client;
+/**
+ * Enable MCP client instrumentation by auto-resolving the Client class.
+ * Works in CJS projects. For ESM projects, prefer passing the Client class directly.
+ */
+export function enableMcpClientInstrumentation(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ClientClass?: any,
+): boolean {
+  const Client = ClientClass ?? resolveClientClass();
+  return Client ? patchClient(Client) : false;
+}
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function patchClient(Client: any): boolean {
   if (!Client?.prototype) return false;
   if (Client.prototype[PATCHED_FLAG]) return true;
 


### PR DESCRIPTION
## Summary

- **Fixed CJS/ESM module duplication bug** — `createRequire()` loaded a different `Client.prototype` than `import`, so patches went to the wrong copy. Zero CLIENT spans in Jaeger.
- `enableMcpClientInstrumentation()` now accepts optional `Client` class parameter — pass the same class you imported for guaranteed ESM compatibility
- Without the parameter, falls back to `createRequire` (works in CJS)
- Removed `enableMcpClientInstrumentationAsync` (unnecessary with direct class passing)

## Verified in Jaeger

12 spans in one trace — 3 CLIENT→SERVER pairs linked:

```
invoke_agent e2e-demo-agent
├── tools/call calculate   (CLIENT)
│   └── tools/call calculate   (SERVER)  ← parent = CLIENT ✅
├── tools/call get-weather (CLIENT)
│   └── tools/call get-weather (SERVER)  ← parent = CLIENT ✅
├── tools/call timestamp   (CLIENT)
│   └── tools/call timestamp   (SERVER)  ← parent = CLIENT ✅
```

## Test plan

- [x] Build passes
- [x] 278 tests pass
- [x] E2E demo: CLIENT→SERVER spans linked in Jaeger

🤖 Generated with [Claude Code](https://claude.com/claude-code)