### PR TITLE
fix: parentSpanId, ESM server auto-instrument, array redaction (#283)

### DIFF
--- a/packages/instrumentation/src/core/span-end-processor.ts
+++ b/packages/instrumentation/src/core/span-end-processor.ts
@@ -66,8 +66,7 @@ function toSpanEndData(span: ReadableSpan): SpanEndData {
   return {
     traceId: ctx.traceId,
     spanId: ctx.spanId,
-    parentSpanId:
-      (span as unknown as { parentSpanId?: string }).parentSpanId || undefined,
+    parentSpanId: span.parentSpanContext?.spanId,
     name: span.name,
     kind: SPAN_KIND_MAP[span.kind] ?? "internal",
     status:

--- a/packages/instrumentation/src/instrumentations/mcp.ts
+++ b/packages/instrumentation/src/instrumentations/mcp.ts
@@ -22,16 +22,26 @@ let mcpServerProto: any = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let originals: { tool: any; resource?: any; prompt?: any } | null = null;
 
-export function enableMcpInstrumentation(): boolean {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveServerClass(): any {
   try {
-    require.resolve(MODULE_NAME);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const sdk = require(MODULE_NAME);
+    return sdk.McpServer ?? sdk.default?.McpServer;
   } catch {
-    return false;
+    return null;
   }
+}
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const sdk = require(MODULE_NAME);
-  const McpServer = sdk.McpServer ?? sdk.default?.McpServer;
+/**
+ * Enable MCP server auto-instrumentation.
+ * For ESM projects, pass McpServer class directly to avoid CJS/ESM module mismatch.
+ */
+export function enableMcpInstrumentation(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  McpServerClass?: any,
+): boolean {
+  const McpServer = McpServerClass ?? resolveServerClass();
 
   if (!McpServer?.prototype) return false;
   if (McpServer.prototype[PATCHED_FLAG]) return true;

--- a/packages/instrumentation/src/mcp/client.ts
+++ b/packages/instrumentation/src/mcp/client.ts
@@ -78,6 +78,7 @@ export function enableMcpClientInstrumentation(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function patchClient(Client: any): boolean {
   if (!Client?.prototype) return false;
+  if (typeof Client.prototype.callTool !== "function") return false;
   if (Client.prototype[PATCHED_FLAG]) return true;
 
   const proto = Client.prototype;

--- a/packages/instrumentation/src/mcp/middleware.ts
+++ b/packages/instrumentation/src/mcp/middleware.ts
@@ -55,6 +55,16 @@ function truncate(value: string, maxBytes: number): string {
   return value.slice(0, maxBytes) + "...[truncated]";
 }
 
+function redactValue(v: unknown, keys: readonly string[]): unknown {
+  if (Array.isArray(v)) {
+    return v.map((item) => redactValue(item, keys));
+  }
+  if (typeof v === "object" && v !== null) {
+    return redactObject(v, keys);
+  }
+  return v;
+}
+
 function redactObject(
   obj: unknown,
   keys: readonly string[],
@@ -64,10 +74,8 @@ function redactObject(
   for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
     if (keys.includes(k)) {
       result[k] = "[REDACTED]";
-    } else if (typeof v === "object" && v !== null && !Array.isArray(v)) {
-      result[k] = redactObject(v, keys);
     } else {
-      result[k] = v;
+      result[k] = redactValue(v, keys);
     }
   }
   return result;
@@ -97,7 +105,10 @@ function redactObject(
  * In stdio MCP transport, stdout IS the JSON-RPC channel —
  * any stray console.log or OTel diagnostic would crash the connection.
  */
+let stdioSafe = false;
 function ensureStdioSafe() {
+  if (stdioSafe) return;
+  stdioSafe = true;
   const stderrLogger = new DiagConsoleLogger();
   // Override the logger to use stderr-only methods
   const safeLogger = {


### PR DESCRIPTION
## Summary

5 fixes from code review round 2:

1. **`SpanEndData.parentSpanId`** was always `undefined` — read non-existent property instead of `span.parentSpanContext?.spanId`
2. **Server auto-instrumentation** had same CJS/ESM issue as client (#282). `enableMcpInstrumentation()` now accepts optional `McpServerClass` param
3. **`redactObject` recurses into arrays** — `{ items: [{ apiKey: "sk-..." }] }` now correctly redacts nested array elements
4. **Shape validation** on `ClientClass` param — passing wrong class returns `false` instead of corrupting prototype
5. **`ensureStdioSafe` guard** — `diag.setLogger` called only once, not on every middleware init

Closes #283

## Test plan

- [x] Build passes
- [x] 278 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)