### PR TITLE
fix(grafana): dashboard PromQL mismatches — empty panels (#284)

### DIFF
--- a/packages/instrumentation/templates/grafana/dashboards/agent-workflow.json
+++ b/packages/instrumentation/templates/grafana/dashboards/agent-workflow.json
@@ -118,7 +118,7 @@
       },
       "targets": [
         {
-          "expr": "count(count by (gen_ai_agent_tool_name) (gen_ai_agent_tool_usage_total))",
+          "expr": "count(count by (gen_ai_tool_name) (gen_ai_agent_tool_usage_total))",
           "refId": "A"
         }
       ],
@@ -175,8 +175,8 @@
       },
       "targets": [
         {
-          "expr": "sort_desc(sum by (gen_ai_agent_tool_name) (gen_ai_agent_tool_usage_total))",
-          "legendFormat": "{{gen_ai_agent_tool_name}}",
+          "expr": "sort_desc(sum by (gen_ai_tool_name) (gen_ai_agent_tool_usage_total))",
+          "legendFormat": "{{gen_ai_tool_name}}",
           "refId": "A"
         }
       ]
@@ -231,8 +231,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (gen_ai_agent_tool_name) (rate(gen_ai_agent_tool_usage_total[5m]))",
-          "legendFormat": "{{gen_ai_agent_tool_name}}",
+          "expr": "sum by (gen_ai_tool_name) (rate(gen_ai_agent_tool_usage_total[5m]))",
+          "legendFormat": "{{gen_ai_tool_name}}",
           "refId": "A"
         }
       ],
@@ -283,45 +283,13 @@
   "schemaVersion": 39,
   "tags": ["toad-eye", "agent"],
   "templating": {
-    "list": [
-      {
-        "name": "service",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "query": "label_values(gen_ai_client_requests_total, job)",
-        "includeAll": true,
-        "allValue": ".*",
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
-        "multi": true
-      },
-      {
-        "name": "tool",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "query": "label_values(gen_ai_agent_tool_usage_total, gen_ai_agent_tool_name)",
-        "includeAll": true,
-        "multi": true,
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
-        "regex": ""
-      }
-    ]
+    "list": []
   },
   "time": {
     "from": "now-6h",
     "to": "now"
   },
+  "refresh": "30s",
   "timepicker": {},
   "timezone": "utc",
   "title": "toad-eye / Agent Workflow",

--- a/packages/instrumentation/templates/grafana/dashboards/finops-attribution.json
+++ b/packages/instrumentation/templates/grafana/dashboards/finops-attribution.json
@@ -419,6 +419,7 @@
     "from": "now-7d",
     "to": "now"
   },
+  "refresh": "1m",
   "timepicker": {},
   "timezone": "utc",
   "title": "toad-eye / FinOps Attribution",

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
@@ -287,6 +287,7 @@
     "from": "now-1h",
     "to": "now"
   },
+  "refresh": "30s",
   "timepicker": {},
   "timezone": "browser",
   "title": "MCP Tool Analytics",

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-e2e.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-e2e.json
@@ -43,7 +43,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(gen_ai_client_operation_duration_sum[5m])) / sum(rate(gen_ai_client_operation_duration_count[5m])) or vector(0)",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum[5m])) / sum(rate(gen_ai_client_operation_duration_milliseconds_count[5m])) or vector(0)",
           "refId": "A"
         }
       ],
@@ -124,7 +124,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(gen_ai_client_operation_duration_sum[5m])) / sum(rate(gen_ai_client_operation_duration_count[5m]))",
+          "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum[5m])) / sum(rate(gen_ai_client_operation_duration_milliseconds_count[5m]))",
           "legendFormat": "LLM Avg Latency",
           "refId": "A"
         },
@@ -315,6 +315,7 @@
     "from": "now-1h",
     "to": "now"
   },
+  "refresh": "30s",
   "timepicker": {},
   "timezone": "browser",
   "title": "MCP End-to-End",

--- a/packages/instrumentation/templates/grafana/dashboards/provider-health.json
+++ b/packages/instrumentation/templates/grafana/dashboards/provider-health.json
@@ -166,7 +166,7 @@
       }
     },
     {
-      "title": "Error Breakdown by Type",
+      "title": "Error Breakdown by Model",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -180,8 +180,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (gen_ai_provider_name, error_type) (rate(gen_ai_client_errors_total{job=~\"$service\", gen_ai_provider_name=~\"$provider\"}[5m]))",
-          "legendFormat": "{{gen_ai_provider_name}} — {{error_type}}",
+          "expr": "sum by (gen_ai_provider_name, gen_ai_request_model) (rate(gen_ai_client_errors_total{job=~\"$service\", gen_ai_provider_name=~\"$provider\"}[5m]))",
+          "legendFormat": "{{gen_ai_provider_name}} — {{gen_ai_request_model}}",
           "refId": "A"
         }
       ],
@@ -276,6 +276,7 @@
         },
         "query": "label_values(gen_ai_client_requests_total, gen_ai_provider_name)",
         "includeAll": true,
+        "allValue": ".*",
         "multi": true,
         "current": {
           "text": "All",
@@ -289,6 +290,7 @@
     "from": "now-6h",
     "to": "now"
   },
+  "refresh": "30s",
   "timepicker": {},
   "timezone": "utc",
   "title": "toad-eye / Provider Health",


### PR DESCRIPTION
## Summary

Fixed multiple dashboard panels showing "No data" due to metric/label name mismatches:

- **mcp-e2e.json:** `gen_ai_client_operation_duration_sum` → `_milliseconds_sum` (OTel appends unit)
- **agent-workflow.json:** `gen_ai_agent_tool_name` → `gen_ai_tool_name` (6 occurrences). Removed unused `$service`/`$tool` template variables
- **provider-health.json:** "Error Breakdown by Type" → "by Model" (error_type label doesn't exist on error counter, switched to gen_ai_request_model). Added `allValue: ".*"` to `$provider` variable
- **All 5 dashboards:** Added `"refresh"` auto-refresh (30s operational, 1m finops)

Closes #284

## Test plan

- [x] Build passes
- [x] 278 tests pass
- [ ] Visual verify: `npx toad-eye init --force && npx toad-eye up` + send traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)