### PR TITLE
fix: demo + alerting robustness (#285)

### DIFF
--- a/demo/src/mcp-e2e/index.ts
+++ b/demo/src/mcp-e2e/index.ts
@@ -38,7 +38,7 @@ const server = new McpServer({
   version: "1.0.0",
 });
 
-toadEyeMiddleware(server, {
+const dispose = toadEyeMiddleware(server, {
   recordInputs: true,
   recordOutputs: true,
 });
@@ -133,6 +133,7 @@ async function main() {
 
   // Clean up
   await client.close();
+  dispose();
   await new Promise((r) => setTimeout(r, 2000));
   await shutdown();
 }

--- a/demo/src/mcp-server/http.ts
+++ b/demo/src/mcp-server/http.ts
@@ -28,8 +28,9 @@ initObservability({
   endpoint: process.env["OTEL_EXPORTER_ENDPOINT"] ?? "http://localhost:4318",
 });
 
-// Track sessions
+// Track sessions and dispose handles
 const transports = new Map<string, StreamableHTTPServerTransport>();
+const disposeHandles = new Map<string, () => void>();
 
 function createMcpServer() {
   const server = new McpServer({
@@ -37,7 +38,7 @@ function createMcpServer() {
     version: "1.0.0",
   });
 
-  toadEyeMiddleware(server, {
+  const dispose = toadEyeMiddleware(server, {
     recordInputs: true,
     recordOutputs: true,
   });
@@ -63,7 +64,7 @@ function createMcpServer() {
     ],
   }));
 
-  return server;
+  return { server, dispose };
 }
 
 const httpServer = createServer(async (req, res) => {
@@ -90,7 +91,20 @@ const httpServer = createServer(async (req, res) => {
   // POST — tool calls and initialize
   if (req.method === "POST") {
     const body = await readBody(req);
-    const parsed = JSON.parse(body);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
+        }),
+      );
+      return;
+    }
 
     if (sessionId && transports.has(sessionId)) {
       await transports.get(sessionId)!.handleRequest(req, res, parsed);
@@ -109,13 +123,16 @@ const httpServer = createServer(async (req, res) => {
       transport.onclose = () => {
         if (transport.sessionId) {
           transports.delete(transport.sessionId);
+          disposeHandles.get(transport.sessionId)?.();
+          disposeHandles.delete(transport.sessionId);
           console.error(`  Session closed: ${transport.sessionId}`);
         }
       };
 
-      const server = createMcpServer();
+      const { server, dispose } = createMcpServer();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await server.connect(transport as any);
+      if (transport.sessionId) disposeHandles.set(transport.sessionId, dispose);
       await transport.handleRequest(req, res, parsed);
       return;
     }
@@ -157,10 +174,21 @@ const httpServer = createServer(async (req, res) => {
   res.end("Method Not Allowed");
 });
 
+const MAX_BODY_BYTES = 1_048_576; // 1 MB
+
 function readBody(req: import("node:http").IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        req.destroy();
+        reject(new Error("Body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => resolve(Buffer.concat(chunks).toString()));
     req.on("error", reject);
   });

--- a/packages/instrumentation/src/alerts/channels.ts
+++ b/packages/instrumentation/src/alerts/channels.ts
@@ -14,7 +14,7 @@ function smtpCacheKey(
 function formatMessage(alert: FiredAlert): string {
   const topModelsText =
     alert.topModels.length > 0
-      ? `\nTop models by spend:\n${alert.topModels.map((m) => `  • ${m.model}: $${m.value.toFixed(4)}`).join("\n")}`
+      ? `\nTop contributors:\n${alert.topModels.map((m) => `  • ${m.model}: ${m.value.toFixed(4)}`).join("\n")}`
       : "";
   return [
     `🚨 Alert: ${alert.rule.name}`,
@@ -40,6 +40,7 @@ async function sendTelegram(
         chat_id: config.chatId,
         text: formatMessage(alert),
       }),
+      signal: AbortSignal.timeout(10_000),
     },
   );
   if (!res.ok) throw new Error(`Telegram send failed: ${res.status}`);
@@ -53,6 +54,7 @@ async function sendSlackWebhook(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text: formatMessage(alert) }),
+    signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) throw new Error(`Slack webhook failed: ${res.status}`);
 }
@@ -64,6 +66,7 @@ async function sendWebhook(
   const res = await fetch(config.url, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...config.headers },
+    signal: AbortSignal.timeout(10_000),
     body: JSON.stringify({
       alertName: alert.rule.name,
       metric: alert.rule.metric,

--- a/packages/instrumentation/src/alerts/conditions.ts
+++ b/packages/instrumentation/src/alerts/conditions.ts
@@ -134,7 +134,7 @@ async function queryScalar(
   promql: string,
 ): Promise<number> {
   const url = `${prometheusUrl}/api/v1/query?query=${encodeURIComponent(promql)}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
   if (!res.ok)
     throw new Error(`Prometheus query failed: ${res.status} ${res.statusText}`);
   const data = (await res.json()) as {
@@ -151,7 +151,7 @@ async function queryTopModels(
 ): Promise<Array<{ model: string; value: number }>> {
   const promql = buildTopModelsQuery(metric, window);
   const url = `${prometheusUrl}/api/v1/query?query=${encodeURIComponent(promql)}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
   if (!res.ok) return [];
   const labelKey = isMcpMetric(metric)
     ? "gen_ai_tool_name"

--- a/packages/instrumentation/src/alerts/grafana.ts
+++ b/packages/instrumentation/src/alerts/grafana.ts
@@ -17,6 +17,7 @@ export async function postGrafanaAnnotation(
   const res = await fetch(`${grafanaUrl}/api/annotations`, {
     method: "POST",
     headers,
+    signal: AbortSignal.timeout(10_000),
     body: JSON.stringify({
       time: Date.now(),
       tags: ["toad-eye", "alert", alert.name],

--- a/packages/instrumentation/src/alerts/manager.ts
+++ b/packages/instrumentation/src/alerts/manager.ts
@@ -19,6 +19,7 @@ export class AlertManager {
   }
 
   start() {
+    if (this.intervalId !== undefined) return;
     const configured =
       this.config.evalIntervalSeconds ?? DEFAULT_EVAL_INTERVAL_SECONDS;
     const clampedSeconds = Math.max(configured, MIN_EVAL_INTERVAL_SECONDS);


### PR DESCRIPTION
## Summary

**Demos:**
- E2E demo: capture and call `dispose()` on cleanup — session counter properly decrements
- HTTP demo: `JSON.parse` wrapped in try/catch, returns JSON-RPC `-32700` on malformed input
- HTTP demo: `readBody` capped at 1MB
- HTTP demo: `dispose()` called on session close via `disposeHandles` map

**Alerting:**
- All `fetch()` calls have `AbortSignal.timeout(10_000)` — network hangs no longer block eval loop indefinitely (channels, conditions, grafana)
- `AlertManager.start()` has double-start guard — second call is no-op instead of leaking interval
- "Top models by spend" → "Top contributors" — accurate label for both LLM and MCP alerts

Closes #285

## Test plan

- [x] Build passes
- [x] 278 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)