### PR TITLE
test(mcp): add client instrumentation unit tests (#286)

### DIFF
--- a/packages/instrumentation/src/__tests__/mcp/client.test.ts
+++ b/packages/instrumentation/src/__tests__/mcp/client.test.ts
@@ -76,8 +76,9 @@ describe("enableMcpClientInstrumentation", () => {
 
   it("records error status on callTool failure", async () => {
     class FailingClient extends MockClient {
-      override async callTool() {
+      override async callTool(_params: Record<string, unknown>) {
         throw new TypeError("connection refused");
+        return undefined as never;
       }
     }
 
@@ -85,7 +86,10 @@ describe("enableMcpClientInstrumentation", () => {
     const client = new FailingClient();
 
     await expect(
-      client.callTool({ name: "broken", arguments: {} }),
+      client.callTool({ name: "broken", arguments: {} } as Record<
+        string,
+        unknown
+      >),
     ).rejects.toThrow("connection refused");
 
     const span = findSpan("tools/call broken");


### PR DESCRIPTION
## Summary

7 new tests for MCP client instrumentation — was at zero coverage:

- Patches prototype and creates CLIENT spans with correct attributes
- Idempotent (second call returns true, no double-wrapping)
- Shape validation returns false for wrong class
- `disableMcpClientInstrumentation` restores original methods
- Error status recorded on callTool failure
- readResource and getPrompt create CLIENT spans
- dispose() callable and idempotent

Test count: 278 → 285

Closes #286

## Test plan

- [x] 285 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)