### PR TITLE
chore: release v2.10.0 — review round 2 bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ Full metrics and span attribute reference: [COMPATIBILITY.md](packages/instrumen
 
 ## Tech Stack
 
-TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (278+ tests)
+TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (285+ tests)

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -169,4 +169,4 @@ Full metrics and span attribute reference: [COMPATIBILITY.md](https://github.com
 
 ## Tech Stack
 
-TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (278+ tests)
+TypeScript · OpenTelemetry SDK 2.x · Hono · Docker Compose (Prometheus, Jaeger, Grafana, OTel Collector) · Vitest (285+ tests)

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toad-eye",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "description": "Observability for MCP servers and LLM applications — traces, metrics, dashboards. One-line instrumentation for OpenAI, Anthropic, Gemini, and MCP. Self-hosted with Grafana + Prometheus + Jaeger.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump `2.9.2` → `2.10.0`. Test count 278 → 285. Both READMEs synced.

## What's new in v2.10.0

- fix: `SpanEndData.parentSpanId` reads `span.parentSpanContext?.spanId` (#283)
- fix: `enableMcpInstrumentation()` accepts optional `McpServerClass` for ESM (#283)
- fix: `redactObject` recurses into arrays (#283)
- fix: dashboard PromQL — mcp-e2e duration, agent-workflow tool labels, provider-health error panel (#284)
- fix: HTTP demo `JSON.parse` crash, `readBody` 1MB limit, `dispose()` on session close (#285)
- fix: alerting `fetch` 10s timeouts, `AlertManager.start()` double-start guard (#285)
- test: 7 new MCP client instrumentation tests (#286)

## Publish

After merge: `cd packages/instrumentation && npm publish`

`npm pack --dry-run` shows README.md 6.3kB ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)