### PR TITLE
feat: empty dashboard UX — no-data messages, post-up guidance, auto-open Grafana (#293)

### DIFF
--- a/packages/instrumentation/src/cli.ts
+++ b/packages/instrumentation/src/cli.ts
@@ -116,9 +116,12 @@ function up() {
   });
   console.log();
   status();
+  console.log("   Dashboards will be empty until data arrives.\n");
+  console.log("   Next steps:");
   console.log(
-    "   Run 'npx toad-eye demo' to send test data and verify the stack works.",
+    "     npx toad-eye demo          ← send mock traffic, see data in Grafana",
   );
+  console.log("     or add toad-eye to your app  (see README)");
 }
 
 function down() {
@@ -255,16 +258,31 @@ async function demo() {
 
   console.log("🐸👁️ toad-eye demo — sending mock LLM traffic");
   console.log("    Press Ctrl+C to stop\n");
-  console.log("✅ Stack verified! Add this to your app:\n");
-  console.log(
-    "   import { initObservability } from 'toad-eye';\n   initObservability({ serviceName: 'my-app', instrument: ['openai'] });\n",
-  );
 
   process.on("SIGINT", async () => {
     console.log("\n\u{1f44b} Shutting down...");
     await shutdown();
     process.exit(0);
   });
+
+  let opened = false;
+  function openGrafana() {
+    if (opened) return;
+    opened = true;
+    const url = "http://localhost:3100";
+    const cmd =
+      process.platform === "darwin"
+        ? "open"
+        : process.platform === "win32"
+          ? "start"
+          : "xdg-open";
+    try {
+      spawn(cmd, [url], { detached: true, stdio: "ignore" }).unref();
+      console.log(`\n  📊 Opened Grafana: ${url}\n`);
+    } catch {
+      console.log(`\n  📊 Open Grafana: ${url} (admin/admin)\n`);
+    }
+  }
 
   const tick = async () => {
     const { provider, model } = pickRandom(DEMO_MODELS);
@@ -275,6 +293,7 @@ async function demo() {
         simulateLLMCall(provider, model, prompt),
       );
       console.log(`  \u2705 [${provider}/${model}] ${prompt}`);
+      openGrafana();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.log(`  \u274c [${provider}/${model}] ${msg}`);

--- a/packages/instrumentation/templates/grafana/dashboards/agent-workflow.json
+++ b/packages/instrumentation/templates/grafana/dashboards/agent-workflow.json
@@ -46,7 +46,8 @@
                 "value": 20
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -72,7 +73,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -98,7 +100,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -124,7 +127,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -157,6 +161,11 @@
           "values": ["value", "percent"]
         },
         "pieType": "donut"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
       }
     },
     {
@@ -179,7 +188,12 @@
           "legendFormat": "{{gen_ai_tool_name}}",
           "refId": "A"
         }
-      ]
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
+      }
     },
     {
       "title": "Steps per Query Over Time",
@@ -211,7 +225,8 @@
           "unit": "short",
           "custom": {
             "fillOpacity": 10
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -244,7 +259,8 @@
             "stacking": {
               "mode": "normal"
             }
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -274,7 +290,8 @@
         "defaults": {
           "custom": {
             "fillOpacity": 80
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }

--- a/packages/instrumentation/templates/grafana/dashboards/cost-breakdown.json
+++ b/packages/instrumentation/templates/grafana/dashboards/cost-breakdown.json
@@ -45,7 +45,8 @@
                 "value": 500
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -87,7 +88,8 @@
                 "value": 50
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -129,7 +131,8 @@
                 "value": 1000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -164,7 +167,8 @@
             "stacking": {
               "mode": "normal"
             }
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -199,7 +203,8 @@
             "stacking": {
               "mode": "normal"
             }
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -231,7 +236,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -263,7 +269,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }

--- a/packages/instrumentation/templates/grafana/dashboards/error-drilldown.json
+++ b/packages/instrumentation/templates/grafana/dashboards/error-drilldown.json
@@ -45,7 +45,8 @@
                 "value": 100
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -87,7 +88,8 @@
                 "value": 20
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -129,7 +131,8 @@
                 "value": 50
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -161,7 +164,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -193,7 +197,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -233,7 +238,8 @@
             "stacking": {
               "mode": "normal"
             }
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }

--- a/packages/instrumentation/templates/grafana/dashboards/finops-attribution.json
+++ b/packages/instrumentation/templates/grafana/dashboards/finops-attribution.json
@@ -45,7 +45,8 @@
                 "value": 500
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -88,7 +89,8 @@
                 "value": 1000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -114,7 +116,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -141,7 +144,8 @@
       "fieldConfig": {
         "defaults": {
           "unit": "currencyUSD",
-          "decimals": 4
+          "decimals": 4,
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -173,6 +177,11 @@
           "values": ["value", "percent"]
         },
         "pieType": "donut"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
       }
     },
     {
@@ -197,6 +206,11 @@
       ],
       "options": {
         "stacking": "normal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
       }
     },
     {
@@ -230,7 +244,12 @@
             }
           }
         }
-      ]
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
+      }
     },
     {
       "title": "Top 10 Users by Cost",
@@ -263,7 +282,12 @@
             }
           }
         }
-      ]
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
+      }
     },
     {
       "title": "Daily Cost Trend (by Team)",
@@ -298,7 +322,8 @@
             "stacking": {
               "mode": "normal"
             }
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -342,7 +367,12 @@
             }
           }
         }
-      ]
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No data yet — run: npx toad-eye demo"
+        }
+      }
     }
   ],
   "schemaVersion": 39,

--- a/packages/instrumentation/templates/grafana/dashboards/latency-analysis.json
+++ b/packages/instrumentation/templates/grafana/dashboards/latency-analysis.json
@@ -45,7 +45,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -76,7 +77,8 @@
           "unit": "ms",
           "custom": {
             "fillOpacity": 50
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -108,7 +110,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -140,7 +143,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }

--- a/packages/instrumentation/templates/grafana/dashboards/llm-overview.json
+++ b/packages/instrumentation/templates/grafana/dashboards/llm-overview.json
@@ -45,7 +45,8 @@
                 "value": 10000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -87,7 +88,8 @@
                 "value": 20
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -129,7 +131,8 @@
                 "value": 5000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -171,7 +174,8 @@
                 "value": 100
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -203,7 +207,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -238,7 +243,8 @@
           },
           "color": {
             "mode": "palette-classic"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -275,7 +281,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -307,7 +314,8 @@
             "drawStyle": "bars",
             "fillOpacity": 50,
             "lineWidth": 1
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -349,7 +357,8 @@
                 "value": 1000000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -391,7 +400,8 @@
                 "value": 10000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -433,7 +443,8 @@
                 "value": 100
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-analytics.json
@@ -12,8 +12,16 @@
       "title": "Tool Popularity Ranking",
       "description": "Most called tools by total invocations",
       "type": "bargauge",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "topk(10, sum by (gen_ai_tool_name) (increase(gen_ai_mcp_tool_calls_total[1h])))",
@@ -28,12 +36,25 @@
           "decimals": 0,
           "thresholds": {
             "steps": [
-              { "color": "blue", "value": null },
-              { "color": "green", "value": 10 },
-              { "color": "yellow", "value": 100 },
-              { "color": "red", "value": 500 }
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -49,8 +70,16 @@
       "title": "Unique Callers per Tool",
       "description": "Number of distinct sessions calling each tool",
       "type": "bargauge",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "count by (gen_ai_tool_name) (sum by (gen_ai_tool_name, mcp_session_id) (gen_ai_mcp_tool_callers_total))",
@@ -65,11 +94,21 @@
           "decimals": 0,
           "thresholds": {
             "steps": [
-              { "color": "purple", "value": null },
-              { "color": "blue", "value": 5 },
-              { "color": "green", "value": 20 }
+              {
+                "color": "purple",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 5
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -85,8 +124,16 @@
       "title": "Tool Usage Over Time",
       "description": "Call rate per tool — spot trends and spikes",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (gen_ai_tool_name) (rate(gen_ai_mcp_tool_calls_total[5m]))",
@@ -103,9 +150,14 @@
             "fillOpacity": 20,
             "pointSize": 5,
             "showPoints": "auto",
-            "stacking": { "mode": "none" }
+            "stacking": {
+              "mode": "none"
+            }
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -115,15 +167,25 @@
           "placement": "right",
           "calcs": ["mean", "max", "sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     },
     {
       "title": "Cost per LLM Model (via sampling)",
       "description": "LLM cost breakdown — visible when MCP tools call LLMs internally",
       "type": "piechart",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (gen_ai_request_model) (increase(gen_ai_client_request_cost_USD_sum[1h]))",
@@ -136,7 +198,10 @@
         "defaults": {
           "unit": "currencyUSD",
           "decimals": 4,
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -147,15 +212,25 @@
           "values": ["value", "percent"]
         },
         "pieType": "donut",
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     },
     {
       "title": "Cost Over Time",
       "description": "LLM cost rate — attribute to tools via trace context",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_USD_sum[5m])) * 3600",
@@ -174,7 +249,10 @@
             "pointSize": 5,
             "showPoints": "auto"
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -184,15 +262,25 @@
           "placement": "bottom",
           "calcs": ["sum", "mean"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     },
     {
       "title": "Tool Performance Summary",
       "description": "All tools: call count, avg duration, error rate, unique callers",
       "type": "table",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (gen_ai_tool_name) (increase(gen_ai_mcp_tool_calls_total[1h]))",
@@ -224,11 +312,15 @@
         }
       ],
       "transformations": [
-        { "id": "merge" },
+        {
+          "id": "merge"
+        },
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true },
+            "excludeByName": {
+              "Time": true
+            },
             "renameByName": {
               "gen_ai_tool_name": "Tool",
               "Value #calls": "Calls (1h)",
@@ -241,38 +333,79 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "center" }
+          "custom": {
+            "align": "center"
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Avg Duration (ms)" },
+            "matcher": {
+              "id": "byName",
+              "options": "Avg Duration (ms)"
+            },
             "properties": [
-              { "id": "unit", "value": "ms" },
-              { "id": "decimals", "value": 1 }
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Error Rate" },
+            "matcher": {
+              "id": "byName",
+              "options": "Error Rate"
+            },
             "properties": [
-              { "id": "unit", "value": "percentunit" },
-              { "id": "decimals", "value": 2 },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    { "color": "green", "value": null },
-                    { "color": "yellow", "value": 0.05 },
-                    { "color": "red", "value": 0.1 }
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.05
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.1
+                    }
                   ]
                 }
               },
-              { "id": "custom.displayMode", "value": "color-background" }
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Calls (1h)" },
-            "properties": [{ "id": "decimals", "value": 0 }]
+            "matcher": {
+              "id": "byName",
+              "options": "Calls (1h)"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
           }
         ]
       }

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-e2e.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-e2e.json
@@ -12,8 +12,16 @@
       "title": "Total Request Rate",
       "description": "Combined rate of MCP client + server operations",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(rate(gen_ai_mcp_tool_calls_total[5m])) + sum(rate(gen_ai_client_requests_total[5m])) or vector(0)",
@@ -26,11 +34,21 @@
           "decimals": 2,
           "thresholds": {
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 50 },
-              { "color": "red", "value": 100 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -39,8 +57,16 @@
       "title": "LLM Avg Latency",
       "description": "Average LLM call duration (client-side)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum[5m])) / sum(rate(gen_ai_client_operation_duration_milliseconds_count[5m])) or vector(0)",
@@ -53,11 +79,21 @@
           "decimals": 0,
           "thresholds": {
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1000 },
-              { "color": "red", "value": 5000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -66,8 +102,16 @@
       "title": "Tool Avg Latency",
       "description": "Average MCP tool execution duration (server-side)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(rate(gen_ai_mcp_tool_duration_sum[5m])) / sum(rate(gen_ai_mcp_tool_duration_count[5m])) or vector(0)",
@@ -80,11 +124,21 @@
           "decimals": 0,
           "thresholds": {
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 500 },
-              { "color": "red", "value": 2000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -93,8 +147,16 @@
       "title": "End-to-End Error Rate",
       "description": "Combined error rate across LLM + MCP",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "(sum(rate(gen_ai_client_errors_total[5m])) + sum(rate(gen_ai_mcp_tool_errors_total[5m]))) / (sum(rate(gen_ai_client_requests_total[5m])) + sum(rate(gen_ai_mcp_tool_calls_total[5m]))) or vector(0)",
@@ -107,11 +169,21 @@
           "decimals": 2,
           "thresholds": {
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.05 },
-              { "color": "red", "value": 0.1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -120,8 +192,16 @@
       "title": "Latency Breakdown: LLM vs Tool",
       "description": "Compare LLM call latency vs MCP tool execution latency over time",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(rate(gen_ai_client_operation_duration_milliseconds_sum[5m])) / sum(rate(gen_ai_client_operation_duration_milliseconds_count[5m]))",
@@ -143,24 +223,37 @@
             "fillOpacity": 20,
             "pointSize": 5,
             "showPoints": "auto"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "LLM Avg Latency" },
+            "matcher": {
+              "id": "byName",
+              "options": "LLM Avg Latency"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "orange", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Tool Avg Latency" },
+            "matcher": {
+              "id": "byName",
+              "options": "Tool Avg Latency"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "blue", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
               }
             ]
           }
@@ -172,15 +265,25 @@
           "placement": "bottom",
           "calcs": ["mean", "max"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     },
     {
       "title": "Tool Call Waterfall by Tool",
       "description": "Duration per tool over time — identify slow tools",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (gen_ai_tool_name) (rate(gen_ai_mcp_tool_duration_sum[5m])) / sum by (gen_ai_tool_name) (rate(gen_ai_mcp_tool_duration_count[5m]))",
@@ -194,9 +297,14 @@
           "custom": {
             "drawStyle": "bars",
             "fillOpacity": 60,
-            "stacking": { "mode": "normal" }
+            "stacking": {
+              "mode": "normal"
+            }
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -206,15 +314,25 @@
           "placement": "bottom",
           "calcs": ["mean", "sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     },
     {
       "title": "Error Propagation: LLM vs Tool",
       "description": "Error rates split by LLM errors and MCP tool errors",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(rate(gen_ai_client_errors_total[5m]))",
@@ -236,24 +354,37 @@
             "fillOpacity": 30,
             "pointSize": 5,
             "showPoints": "auto"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "LLM Errors" },
+            "matcher": {
+              "id": "byName",
+              "options": "LLM Errors"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Tool Errors" },
+            "matcher": {
+              "id": "byName",
+              "options": "Tool Errors"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "purple", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
               }
             ]
           }
@@ -265,15 +396,25 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     },
     {
       "title": "Cost: LLM Calls",
       "description": "Total LLM cost over time — visible when tools call LLMs via sampling",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_request_cost_USD_sum[5m]))",
@@ -292,7 +433,10 @@
             "pointSize": 5,
             "showPoints": "auto"
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -302,7 +446,9 @@
           "placement": "bottom",
           "calcs": ["sum"]
         },
-        "tooltip": { "mode": "multi" }
+        "tooltip": {
+          "mode": "multi"
+        }
       }
     }
   ],

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-server.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-server.json
@@ -46,7 +46,8 @@
                 "value": 100
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -89,7 +90,8 @@
                 "value": 2000
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -132,7 +134,8 @@
                 "value": 0.1
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -167,7 +170,8 @@
                 "value": null
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -201,7 +205,8 @@
             "fillOpacity": 15,
             "pointSize": 5,
             "showPoints": "auto"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -250,7 +255,8 @@
             "fillOpacity": 10,
             "pointSize": 5,
             "showPoints": "auto"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -297,7 +303,8 @@
           },
           "color": {
             "mode": "palette-classic"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -341,7 +348,8 @@
             "fillOpacity": 15,
             "pointSize": 5,
             "showPoints": "auto"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       },
@@ -423,7 +431,8 @@
         "defaults": {
           "custom": {
             "align": "center"
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": [
           {

--- a/packages/instrumentation/templates/grafana/dashboards/model-comparison.json
+++ b/packages/instrumentation/templates/grafana/dashboards/model-comparison.json
@@ -35,7 +35,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -67,7 +68,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -99,7 +101,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -131,7 +134,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -163,7 +167,8 @@
             "drawStyle": "line",
             "fillOpacity": 15,
             "lineWidth": 2
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }

--- a/packages/instrumentation/templates/grafana/dashboards/provider-health.json
+++ b/packages/instrumentation/templates/grafana/dashboards/provider-health.json
@@ -83,7 +83,8 @@
                 }
               }
             }
-          ]
+          ],
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -113,7 +114,8 @@
           "unit": "reqps",
           "custom": {
             "fillOpacity": 15
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -160,7 +162,8 @@
                 "value": 0.5
               }
             ]
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -193,7 +196,8 @@
             "stacking": {
               "mode": "normal"
             }
-          }
+          },
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }
@@ -241,7 +245,8 @@
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
-          "decimals": 2
+          "decimals": 2,
+          "noValue": "No data yet — run: npx toad-eye demo"
         },
         "overrides": []
       }


### PR DESCRIPTION
## Summary

Fixes the #1 DX issue — user opens Grafana, sees blank charts, leaves.

1. **80 panels across 11 dashboards** show "No data yet — run: npx toad-eye demo" instead of blank
2. **`toad-eye up`** prints clear next steps after stack starts
3. **`toad-eye demo`** auto-opens Grafana in browser after first successful trace

Closes #293

## Test plan

- [x] Build passes
- [x] 285 tests pass
- [x] Dashboard validation passes (0 errors)
- [ ] Manual: `npx toad-eye up` → open Grafana → see "No data yet" messages
- [ ] Manual: `npx toad-eye demo` → Grafana opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)