### PR TITLE
feat: port collision detection before toad-eye up (#294)

### DIFF
--- a/packages/instrumentation/src/cli.ts
+++ b/packages/instrumentation/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawn } from "node:child_process";
+import { createConnection } from "node:net";
 import {
   cpSync,
   existsSync,
@@ -103,6 +104,53 @@ function requireDocker() {
   }
 }
 
+const PORT_CONFIG = [
+  { env: "COLLECTOR_PORT", default: 4318, service: "OTel Collector" },
+  { env: "PROMETHEUS_PORT", default: 9090, service: "Prometheus" },
+  { env: "JAEGER_PORT", default: 16686, service: "Jaeger" },
+  { env: "GRAFANA_PORT", default: 3100, service: "Grafana" },
+] as const;
+
+function getPort(env: string, defaultPort: number): number {
+  const val = process.env[env];
+  return val ? parseInt(val, 10) : defaultPort;
+}
+
+function checkPort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: "127.0.0.1" });
+    socket.setTimeout(500);
+    socket.on("connect", () => {
+      socket.destroy();
+      resolve(true); // port is in use
+    });
+    socket.on("error", () => resolve(false)); // port is free
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function checkPorts() {
+  const conflicts: string[] = [];
+  for (const { env, default: defaultPort, service } of PORT_CONFIG) {
+    const port = getPort(env, defaultPort);
+    const inUse = await checkPort(port);
+    if (inUse) {
+      conflicts.push(
+        `  ❌ Port ${port} is already in use (${service})\n     Fix: stop the other service, or set ${env}=${port + 1}`,
+      );
+    }
+  }
+  if (conflicts.length > 0) {
+    console.error("Port conflicts detected:\n");
+    console.error(conflicts.join("\n\n"));
+    console.error();
+    process.exit(1);
+  }
+}
+
 function up() {
   requireDocker();
   const composeFile = requireInfra();
@@ -111,17 +159,24 @@ function up() {
   console.log(
     "   (first run downloads ~500MB of Docker images — this may take a few minutes)\n",
   );
-  execFileSync("docker", ["compose", "-f", composeFile, "up", "-d"], {
-    stdio: "inherit",
-  });
-  console.log();
-  status();
-  console.log("   Dashboards will be empty until data arrives.\n");
-  console.log("   Next steps:");
-  console.log(
-    "     npx toad-eye demo          ← send mock traffic, see data in Grafana",
-  );
-  console.log("     or add toad-eye to your app  (see README)");
+
+  // Check ports synchronously via async wrapper — CLI is short-lived
+  const checkAndStart = async () => {
+    await checkPorts();
+    execFileSync("docker", ["compose", "-f", composeFile, "up", "-d"], {
+      stdio: "inherit",
+    });
+    console.log();
+    status();
+    console.log("   Dashboards will be empty until data arrives.\n");
+    console.log("   Next steps:");
+    console.log(
+      "     npx toad-eye demo          ← send mock traffic, see data in Grafana",
+    );
+    console.log("     or add toad-eye to your app  (see README)");
+  };
+
+  void checkAndStart();
 }
 
 function down() {

--- a/packages/instrumentation/templates/docker-compose.yml
+++ b/packages/instrumentation/templates/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     volumes:
       - ./otel-collector.yml:/etc/otelcol-contrib/config.yaml
     ports:
-      - "4318:4318"
+      - "${COLLECTOR_PORT:-4318}:4318"
     depends_on:
       - jaeger
       - prometheus
@@ -14,14 +14,14 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_PORT:-9090}:9090"
 
   jaeger:
     image: jaegertracing/all-in-one:1.58
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     ports:
-      - "16686:16686"
+      - "${JAEGER_PORT:-16686}:16686"
       - "4317:4317"
 
   grafana:
@@ -33,7 +33,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/llm-overview.json
     ports:
-      - "3100:3000"
+      - "${GRAFANA_PORT:-3100}:3000"
     depends_on:
       - prometheus
       - jaeger


### PR DESCRIPTION
## Summary

- **Port check before `docker compose up`** — probes 4318, 9090, 16686, 3100 with `net.createConnection`. If occupied, shows clear error with fix:
  ```
  ❌ Port 3100 is already in use (Grafana)
     Fix: stop the other service, or set GRAFANA_PORT=3101
  ```
- **Env var overrides** in docker-compose.yml: `COLLECTOR_PORT`, `PROMETHEUS_PORT`, `JAEGER_PORT`, `GRAFANA_PORT`

Closes #294

## Test plan

- [x] Build passes
- [x] 285 tests pass
- [ ] Manual: start Grafana on 3100, run `npx toad-eye up` → see port conflict error
- [ ] Manual: `GRAFANA_PORT=3101 npx toad-eye up` → starts on alternate port

🤖 Generated with [Claude Code](https://claude.com/claude-code)