### PR TITLE
feat(mcp): tool hallucination metric — track -32601 as unique signal (#295)

### DIFF
--- a/packages/instrumentation/src/alerts/conditions.ts
+++ b/packages/instrumentation/src/alerts/conditions.ts
@@ -14,6 +14,7 @@ const METRIC_MAP: Record<string, string> = {
   "gen_ai.mcp.tool.duration": "gen_ai_mcp_tool_duration",
   "gen_ai.mcp.resource.reads": "gen_ai_mcp_resource_reads_total",
   "gen_ai.mcp.tool.callers": "gen_ai_mcp_tool_callers_total",
+  "gen_ai.mcp.tool.hallucinations": "gen_ai_mcp_tool_hallucinations_total",
   // Legacy names (backward compat)
   "llm.request.cost": "gen_ai_client_request_cost_USD_sum",
   "llm.request.duration": "gen_ai_client_operation_duration_milliseconds",

--- a/packages/instrumentation/src/mcp/client.ts
+++ b/packages/instrumentation/src/mcp/client.ts
@@ -9,6 +9,7 @@
 import { createRequire } from "node:module";
 import { trace, context, propagation, SpanKind } from "@opentelemetry/api";
 import { MCP_METHODS, endSpanSuccess, endSpanError } from "./spans.js";
+import { recordMcpToolHallucination } from "./metrics.js";
 
 const require = createRequire(import.meta.url);
 
@@ -118,6 +119,11 @@ function patchClient(Client: any): boolean {
       return result;
     } catch (error) {
       endSpanError(span, error);
+      // JSON-RPC -32601 = Method not found = agent hallucinated a tool name
+      const code = (error as Record<string, unknown> | null)?.code;
+      if (code === -32601) {
+        recordMcpToolHallucination(toolName);
+      }
       throw error;
     }
   };

--- a/packages/instrumentation/src/mcp/index.ts
+++ b/packages/instrumentation/src/mcp/index.ts
@@ -9,3 +9,4 @@ export {
   enableMcpClientInstrumentation,
   disableMcpClientInstrumentation,
 } from "./client.js";
+export { recordMcpToolHallucination } from "./metrics.js";

--- a/packages/instrumentation/src/mcp/metrics.ts
+++ b/packages/instrumentation/src/mcp/metrics.ts
@@ -21,6 +21,7 @@ const METER_NAME = "toad-eye-mcp";
 let toolDuration: Histogram;
 let toolCalls: Counter;
 let toolErrors: Counter;
+let toolHallucinations: Counter;
 let resourceReads: Counter;
 let sessionActive: UpDownCounter;
 let toolCallers: Counter;
@@ -45,6 +46,13 @@ function ensureInit() {
   toolErrors = meter.createCounter(GEN_AI_METRICS.MCP_TOOL_ERRORS, {
     description: "MCP tool errors by tool name and error type",
   });
+
+  toolHallucinations = meter.createCounter(
+    GEN_AI_METRICS.MCP_TOOL_HALLUCINATIONS,
+    {
+      description: "Agent tried to call a non-existent tool (JSON-RPC -32601)",
+    },
+  );
 
   resourceReads = meter.createCounter(GEN_AI_METRICS.MCP_RESOURCE_READS, {
     description: "MCP resource read count by URI",
@@ -104,6 +112,14 @@ export function recordMcpResourceRead(uri: string) {
 export function recordMcpSessionStart() {
   ensureInit();
   sessionActive.add(1);
+}
+
+export function recordMcpToolHallucination(toolName: string) {
+  ensureInit();
+  toolHallucinations.add(1, {
+    "gen_ai.tool.name": toolName,
+    "mcp.method.name": MCP_METHODS.TOOLS_CALL,
+  });
 }
 
 export function recordMcpSessionEnd() {

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -40,6 +40,7 @@ export const GEN_AI_METRICS = {
   MCP_RESOURCE_READS: "gen_ai.mcp.resource.reads",
   MCP_SESSION_ACTIVE: "gen_ai.mcp.session.active",
   MCP_TOOL_CALLERS: "gen_ai.mcp.tool.callers",
+  MCP_TOOL_HALLUCINATIONS: "gen_ai.mcp.tool.hallucinations",
 } as const;
 
 /** @deprecated Use GEN_AI_METRICS instead. Kept for backward compatibility. */

--- a/packages/instrumentation/templates/grafana/dashboards/mcp-server.json
+++ b/packages/instrumentation/templates/grafana/dashboards/mcp-server.json
@@ -177,6 +177,34 @@
       }
     },
     {
+      "title": "Tool Hallucination Rate",
+      "description": "Agent tried to call a non-existent tool (JSON-RPC -32601). Spikes indicate the LLM lost track of available tools.",
+      "type": "stat",
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(gen_ai_mcp_tool_hallucinations_total[5m])) or vector(0)",
+          "legendFormat": "hallucinations/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.1 }
+            ]
+          },
+          "noValue": "No hallucinations detected"
+        },
+        "overrides": []
+      }
+    },
+    {
       "title": "Tool Call Rate by Tool",
       "type": "timeseries",
       "gridPos": {

--- a/scripts/validate-dashboards.ts
+++ b/scripts/validate-dashboards.ts
@@ -45,6 +45,7 @@ const KNOWN_METRICS = new Set([
   "gen_ai_mcp_tool_errors_total",
   "gen_ai_mcp_resource_reads_total",
   "gen_ai_mcp_tool_callers_total",
+  "gen_ai_mcp_tool_hallucinations_total",
   // UpDownCounter (no suffix)
   "gen_ai_mcp_session_active",
 ]);


### PR DESCRIPTION
## Summary

New metric **`gen_ai.mcp.tool.hallucinations`** — counts when an agent tries to call a non-existent tool (JSON-RPC `-32601`). No competitor tracks this.

- Auto-detected in client instrumentation (`callTool` catch block checks error code)
- `recordMcpToolHallucination(toolName)` exported for manual recording
- "Tool Hallucination Rate" panel in MCP Server Grafana dashboard (green/yellow/red thresholds)
- Added to `METRIC_MAP` for alerting, `validate-dashboards.ts` for CI

**Why it matters:** If hallucination rate spikes after a prompt change, the LLM lost track of available tools. Real quality signal.

Closes #295

## Test plan

- [x] Build passes
- [x] 285 tests pass
- [x] Dashboard validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)