### PR TITLE
feat: light mode — console output without Docker (#296)

### DIFF
--- a/packages/instrumentation/src/core/console-exporter.ts
+++ b/packages/instrumentation/src/core/console-exporter.ts
@@ -1,0 +1,70 @@
+/**
+ * Console span exporter — pretty-prints completed spans to stderr.
+ *
+ * Used in "light mode" (output: "console") — no Docker, no OTel Collector,
+ * just immediate feedback in the terminal.
+ *
+ * Format:
+ *   🐸 tools/call calculate  [42ms] ✅
+ *   🐸 chat gpt-4o  [1.2s] $0.003 ✅
+ *   🐸 tools/call broken  [12ms] ❌ TypeError
+ */
+
+import type { SpanExporter, ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+
+function formatDuration(ms: number): string {
+  if (ms < 1) return "<1ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function getAttr(span: ReadableSpan, key: string): string | number | undefined {
+  const val = span.attributes[key];
+  if (typeof val === "string" || typeof val === "number") return val;
+  return undefined;
+}
+
+function formatSpan(span: ReadableSpan): string {
+  const durationMs =
+    (span.endTime[0] - span.startTime[0]) * 1000 +
+    (span.endTime[1] - span.startTime[1]) / 1_000_000;
+
+  const isError = span.status.code === SpanStatusCode.ERROR;
+  const icon = isError ? "❌" : "✅";
+
+  const cost = getAttr(span, "gen_ai.toad_eye.cost");
+  const costStr =
+    typeof cost === "number" && cost > 0 ? ` $${cost.toFixed(4)}` : "";
+
+  const errorType = isError ? getAttr(span, "error.type") : undefined;
+  const errorStr = errorType ? ` ${errorType}` : "";
+
+  return `  🐸 ${span.name}  [${formatDuration(durationMs)}]${costStr} ${icon}${errorStr}`;
+}
+
+// Filter out internal spans that add noise in console mode
+const SKIP_PREFIXES = ["gen_ai.agent.step."];
+
+function shouldShow(span: ReadableSpan): boolean {
+  return !SKIP_PREFIXES.some((p) => span.name.startsWith(p));
+}
+
+export class ToadEyeConsoleExporter implements SpanExporter {
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ) {
+    for (const span of spans) {
+      if (shouldShow(span)) {
+        process.stderr.write(formatSpan(span) + "\n");
+      }
+    }
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/instrumentation/src/core/tracer.ts
+++ b/packages/instrumentation/src/core/tracer.ts
@@ -25,6 +25,7 @@ import { resetMcpMetrics } from "../mcp/metrics.js";
 import { BudgetTracker } from "../budget/index.js";
 import { ToadEyeAISpanProcessor } from "../vercel.js";
 import { ToadEyeSpanEndProcessor } from "./span-end-processor.js";
+import { ToadEyeConsoleExporter } from "./console-exporter.js";
 import type { LLMProvider } from "../types/index.js";
 
 const DEFAULT_ENDPOINT = "http://localhost:4318";
@@ -98,26 +99,33 @@ export function initObservability(config: ToadEyeConfig) {
   }
 
   validateConfig(config);
-  const { endpoint, headers, isCloudMode } = resolveTransport(config);
+
+  const isConsoleMode = config.output === "console";
+  const { endpoint, headers, isCloudMode } = isConsoleMode
+    ? { endpoint: "", headers: {}, isCloudMode: false }
+    : resolveTransport(config);
 
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: config.serviceName,
   });
 
-  const traceExporter = new OTLPTraceExporter({
-    url: `${endpoint}/v1/traces`,
-    headers,
-  });
+  const traceExporter = isConsoleMode
+    ? new ToadEyeConsoleExporter()
+    : new OTLPTraceExporter({
+        url: `${endpoint}/v1/traces`,
+        headers,
+      });
 
-  const metricExporter = new OTLPMetricExporter({
-    url: `${endpoint}/v1/metrics`,
-    headers,
-  });
-
-  const metricReader = new PeriodicExportingMetricReader({
-    exporter: metricExporter,
-    exportIntervalMillis: isCloudMode ? 10_000 : 5_000,
-  });
+  // In console mode, skip metric export — no Prometheus to send to
+  const metricReader = isConsoleMode
+    ? undefined
+    : new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter({
+          url: `${endpoint}/v1/metrics`,
+          headers,
+        }),
+        exportIntervalMillis: isCloudMode ? 10_000 : 5_000,
+      });
 
   // When custom SpanProcessors are needed (e.g., Vercel AI SDK, onSpanEnd),
   // we must also include a BatchSpanProcessor for trace export —
@@ -149,7 +157,7 @@ export function initObservability(config: ToadEyeConfig) {
   sdk = new NodeSDK({
     resource,
     traceExporter,
-    metricReader,
+    ...(metricReader !== undefined && { metricReader }),
     ...(spanProcessors.length > 0 && { spanProcessors }),
     ...(sampler !== undefined && { sampler }),
   });
@@ -158,9 +166,15 @@ export function initObservability(config: ToadEyeConfig) {
   currentConfig = config;
   initMetrics();
 
+  if (isConsoleMode) {
+    console.log(
+      `toad-eye: console mode — spans will be printed to stderr. No Docker needed.`,
+    );
+  }
+
   // Non-blocking connectivity check — warns the user if the OTel Collector is unreachable.
-  // Fire-and-forget: does not block initObservability(). Cloud mode skips this check.
-  if (!isCloudMode) {
+  // Fire-and-forget: does not block initObservability(). Cloud/console mode skips this check.
+  if (!isCloudMode && !isConsoleMode) {
     void fetch(`${endpoint}/v1/traces`, {
       method: "POST",
       body: "[]",

--- a/packages/instrumentation/src/types/config.ts
+++ b/packages/instrumentation/src/types/config.ts
@@ -31,6 +31,9 @@ export interface ToadEyeConfig {
   readonly serviceName: string;
   readonly endpoint?: string | undefined;
 
+  /** Output mode: "otlp" (default) sends to OTel Collector, "console" prints spans to stderr (no Docker needed). */
+  readonly output?: "otlp" | "console" | undefined;
+
   // Cloud mode
   /** API key for toad-eye cloud. When set, transport switches to HTTPS cloud endpoint automatically. */
   readonly apiKey?: string | undefined;


### PR DESCRIPTION
## Summary

New `output: "console"` mode — prints spans to stderr, no Docker needed.

```typescript
initObservability({
  serviceName: "my-app",
  output: "console",
});
```

Output:
```
🐸 chat gpt-4o  [1.2s] $0.003 ✅
🐸 tools/call calculate  [42ms] ✅
🐸 chat claude-sonnet  [800ms] ❌ rate limit
```

- Skips OTLP exporters and OTel Collector connectivity check
- All features work (traceLLMCall, MCP middleware, agents, onSpanEnd)
- Filters out noisy internal spans (agent step spans)
- Position as "dev mode" vs full stack "production mode"

Closes #296

## Test plan

- [x] Build passes
- [x] 285 tests pass
- [x] Smoke test: spans print to stderr without Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)