### PR TITLE
chore: add Biome linter to CI (#200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm run build --workspace=packages/instrumentation
       - run: npx tsc --noEmit
       - run: npm run format:check
+      - run: npm run lint
       - run: npm run validate:dashboards
       - run: npm run test --workspace=packages/instrumentation
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "packages/instrumentation/src/**/*.ts",
+      "demo/src/**/*.ts",
+      "scripts/**/*.ts"
+    ]
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "warn",
+        "noUnusedVariables": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noConfusingVoidType": "off",
+        "noAssignInExpressions": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useConst": "warn",
+        "noParameterAssign": "off",
+        "useTemplate": "off"
+      },
+      "complexity": {
+        "noForEach": "off",
+        "useLiteralKeys": "off"
+      }
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "demo"
       ],
       "devDependencies": {
+        "@biomejs/biome": "^2.4.9",
         "@types/node": "^25.5.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -36,6 +37,169 @@
       "devDependencies": {
         "dotenv": "^17.3.1",
         "openai": "^6.32.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
+      "integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.9",
+        "@biomejs/cli-darwin-x64": "2.4.9",
+        "@biomejs/cli-linux-arm64": "2.4.9",
+        "@biomejs/cli-linux-arm64-musl": "2.4.9",
+        "@biomejs/cli-linux-x64": "2.4.9",
+        "@biomejs/cli-linux-x64-musl": "2.4.9",
+        "@biomejs/cli-win32-arm64": "2.4.9",
+        "@biomejs/cli-win32-x64": "2.4.9"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
+      "integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
+      "integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
+      "integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
+      "integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
+      "integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
+      "integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
+      "integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
+      "integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4352,7 +4516,7 @@
     },
     "packages/instrumentation": {
       "name": "toad-eye",
-      "version": "2.9.2",
+      "version": "2.10.0",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "validate:dashboards": "npx tsx scripts/validate-dashboards.ts",
+    "lint": "biome check",
+    "lint:fix": "biome check --write --unsafe",
     "prepare": "husky"
   },
   "author": "albertalov",
   "license": "ISC",
   "devDependencies": {
+    "@biomejs/biome": "^2.4.9",
     "@types/node": "^25.5.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",

--- a/packages/instrumentation/src/__tests__/auto-instrumentation.test.ts
+++ b/packages/instrumentation/src/__tests__/auto-instrumentation.test.ts
@@ -48,11 +48,11 @@ function buildGeminiSdk(modelName: string) {
   class GenerativeModel {
     model = modelName;
 
-    async generateContent(body: unknown) {
+    async generateContent(_body: unknown) {
       return { response: { text: () => "hello", usageMetadata: {} } };
     }
 
-    async generateContentStream(body: unknown) {
+    async generateContentStream(_body: unknown) {
       async function* stream() {
         yield { text: () => "chunk1", usageMetadata: {} };
         yield {
@@ -81,7 +81,7 @@ describe("Gemini model name extraction from thisArg", () => {
         {
           getPrototype: (m) => m?.GenerativeModel?.prototype,
           method: "generateContent",
-          extractRequest: (body, thisArg) => ({
+          extractRequest: (_body, thisArg) => ({
             prompt: "",
             model:
               (thisArg as { model?: string } | undefined)?.model ?? "unknown",
@@ -118,7 +118,7 @@ describe("Gemini model name extraction from thisArg", () => {
   });
 
   it("extractRequest receives thisArg with correct model", () => {
-    const extractRequest = vi.fn((body: unknown, thisArg?: unknown) => ({
+    const extractRequest = vi.fn((_body: unknown, thisArg?: unknown) => ({
       prompt: "test",
       model: (thisArg as { model?: string } | undefined)?.model ?? "unknown",
     }));
@@ -129,7 +129,7 @@ describe("Gemini model name extraction from thisArg", () => {
   });
 
   it("falls back to unknown when thisArg has no model", () => {
-    const extractRequest = (body: unknown, thisArg?: unknown) => ({
+    const extractRequest = (_body: unknown, thisArg?: unknown) => ({
       prompt: "",
       model: (thisArg as { model?: string } | undefined)?.model ?? "unknown",
     });
@@ -167,7 +167,7 @@ describe("streaming path quality metrics", () => {
       for (const c of chunks) yield c;
     }
 
-    let streamProduced: AsyncIterable<unknown> | undefined;
+    let _streamProduced: AsyncIterable<unknown> | undefined;
 
     const inst = createInstrumentation({
       name: "openai",
@@ -204,8 +204,8 @@ describe("streaming path quality metrics", () => {
     };
 
     // Bypass module loading — patch the prototype directly
-    const originalCreate = fakeProto.create;
-    const patchTarget = inst as unknown as { _patches?: unknown[] };
+    const _originalCreate = fakeProto.create;
+    const _patchTarget = inst as unknown as { _patches?: unknown[] };
 
     // Use a simpler approach: test the streaming accumulator logic directly
     const acc = { completion: "", inputTokens: 0, outputTokens: 0 };

--- a/packages/instrumentation/src/__tests__/budget.test.ts
+++ b/packages/instrumentation/src/__tests__/budget.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { BudgetTracker } from "../budget/tracker.js";
 import { ToadBudgetExceededError } from "../budget/error.js";

--- a/packages/instrumentation/src/__tests__/mcp/client.test.ts
+++ b/packages/instrumentation/src/__tests__/mcp/client.test.ts
@@ -1,28 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
-import { SpanKind, trace, context } from "@opentelemetry/api";
+import { SpanKind } from "@opentelemetry/api";
 import {
   enableMcpClientInstrumentation,
   disableMcpClientInstrumentation,
 } from "../../mcp/client.js";
-import { extractContextFromMeta } from "../../mcp/context.js";
 import { toadEyeMiddleware } from "../../mcp/middleware.js";
 import {
   setupOTelForTests,
   findSpan,
   getSpanAttr,
-  getSpans,
   SpanStatusCode,
 } from "./test-utils.js";
 
 // Minimal mock Client class that behaves like @modelcontextprotocol/sdk Client
 class MockClient {
-  async callTool(params: Record<string, unknown>) {
+  async callTool(_params: Record<string, unknown>) {
     return { content: [{ type: "text", text: "mock result" }] };
   }
   async readResource(params: Record<string, unknown>) {
     return { contents: [{ uri: params.uri, text: "data" }] };
   }
-  async getPrompt(params: Record<string, unknown>) {
+  async getPrompt(_params: Record<string, unknown>) {
     return {
       messages: [{ role: "user", content: { type: "text", text: "hi" } }],
     };
@@ -76,9 +74,10 @@ describe("enableMcpClientInstrumentation", () => {
 
   it("records error status on callTool failure", async () => {
     class FailingClient extends MockClient {
-      override async callTool(_params: Record<string, unknown>) {
+      override async callTool(
+        _params: Record<string, unknown>,
+      ): Promise<never> {
         throw new TypeError("connection refused");
-        return undefined as never;
       }
     }
 

--- a/packages/instrumentation/src/__tests__/mcp/middleware.test.ts
+++ b/packages/instrumentation/src/__tests__/mcp/middleware.test.ts
@@ -5,7 +5,6 @@ import {
   setupOTelForTests,
   findSpan,
   getSpanAttr,
-  getSpans,
   SpanStatusCode,
 } from "./test-utils.js";
 

--- a/packages/instrumentation/src/__tests__/span-end-processor.test.ts
+++ b/packages/instrumentation/src/__tests__/span-end-processor.test.ts
@@ -95,7 +95,7 @@ describe("ToadEyeSpanEndProcessor", () => {
     });
 
     // Call onEnd directly — no need for a full provider
-    const span = exporter.getFinishedSpans()[0];
+    const _span = exporter.getFinishedSpans()[0];
     // Create a real span to pass
     const tracer = trace.getTracer("test");
     const testSpan = tracer.startSpan("direct-test");

--- a/packages/instrumentation/src/instrumentations/create.ts
+++ b/packages/instrumentation/src/instrumentations/create.ts
@@ -24,7 +24,6 @@ import {
   recordBudgetDowngraded,
 } from "../core/metrics.js";
 import { getConfig, getBudgetTracker } from "../core/tracer.js";
-import { ToadBudgetExceededError } from "../budget/index.js";
 import { GEN_AI_ATTRS, INSTRUMENTATION_NAME } from "../types/index.js";
 import type { LLMProvider } from "../types/index.js";
 import type {


### PR DESCRIPTION
## Summary

- Added Biome for linting (Prettier stays for formatting)
- Catches unused imports/variables, unreachable code
- Auto-fixed 6 files (removed unused imports, fixed unreachable code in test)
- CI pipeline now: typecheck → format → **lint** → validate dashboards → test

Closes #200

## Test plan

- [x] Build passes
- [x] 285 tests pass
- [x] `npm run lint` clean (1 minor warning)
- [x] `npm run format:check` still passes (no conflict with Prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)