### PR TITLE
feat: reasoning trace for thinking models (#39)

### DIFF
--- a/packages/instrumentation/src/core/metrics.ts
+++ b/packages/instrumentation/src/core/metrics.ts
@@ -25,6 +25,7 @@ let responseEmpty: Counter;
 let responseLatencyPerToken: Histogram;
 let contextUtilization: Histogram;
 let contextBlocked: Counter;
+let thinkingRatio: Histogram;
 
 let initialized = false;
 
@@ -128,6 +129,11 @@ export function initMetrics() {
 
   contextBlocked = meter.createCounter(GEN_AI_METRICS.CONTEXT_BLOCKED, {
     description: "Number of LLM calls blocked by context guard",
+  });
+
+  thinkingRatio = meter.createHistogram(GEN_AI_METRICS.THINKING_RATIO, {
+    description:
+      "Ratio of thinking/reasoning tokens to total output (0.0–1.0). High values indicate deep reasoning.",
   });
 
   initialized = true;
@@ -317,6 +323,18 @@ export function recordContextUtilization(
 export function recordContextBlocked(model: string) {
   if (!isReady()) return;
   contextBlocked.add(1, {
+    [GEN_AI_ATTRS.REQUEST_MODEL]: model,
+  });
+}
+
+export function recordThinkingRatio(
+  ratio: number,
+  provider: string,
+  model: string,
+) {
+  if (!isReady()) return;
+  thinkingRatio.record(ratio, {
+    [GEN_AI_ATTRS.PROVIDER]: provider,
     [GEN_AI_ATTRS.REQUEST_MODEL]: model,
   });
 }

--- a/packages/instrumentation/src/core/spans.ts
+++ b/packages/instrumentation/src/core/spans.ts
@@ -15,6 +15,7 @@ import {
   recordResponseLatencyPerToken,
   recordContextUtilization,
   recordContextBlocked,
+  recordThinkingRatio,
 } from "./metrics.js";
 import { getConfig, getBudgetTracker } from "./tracer.js";
 import { calculateCost, getModelPricing } from "./pricing.js";
@@ -39,6 +40,10 @@ export interface LLMCallOutput {
   readonly outputTokens: number;
   /** Cost in USD. If omitted, auto-calculated from model pricing table. */
   readonly cost?: number | undefined;
+  /** Thinking/reasoning content from thinking models (o1, Claude extended thinking, Gemini). */
+  readonly thinkingContent?: string | undefined;
+  /** Thinking/reasoning tokens used (separate from outputTokens). */
+  readonly thinkingTokens?: number | undefined;
 }
 
 const tracer = trace.getTracer(INSTRUMENTATION_NAME);
@@ -194,6 +199,32 @@ function setSuccessAttributes(
     [GEN_AI_ATTRS.STATUS]: "success",
     [GEN_AI_ATTRS.FINISH_REASONS]: ["stop"],
   });
+
+  // Thinking model support (o1, Claude extended thinking, Gemini)
+  if (output.thinkingTokens !== undefined && output.thinkingTokens > 0) {
+    span.setAttribute("gen_ai.usage.reasoning_tokens", output.thinkingTokens);
+    const ratio =
+      output.thinkingTokens / (output.outputTokens + output.thinkingTokens);
+    span.setAttribute("gen_ai.toad_eye.thinking.ratio", ratio);
+    recordThinkingRatio(ratio, input.provider, input.model);
+  }
+  if (output.thinkingContent !== undefined) {
+    const config = getConfig();
+    const recordThinking = config?.recordContent !== false;
+    if (recordThinking) {
+      const processed = processContent(output.thinkingContent);
+      if (processed !== undefined) {
+        span.addEvent("gen_ai.thinking", {
+          "gen_ai.toad_eye.thinking.content": processed,
+        });
+      }
+    }
+    span.setAttribute(
+      "gen_ai.toad_eye.thinking.content_length",
+      output.thinkingContent.length,
+    );
+  }
+
   span.setStatus({ code: SpanStatusCode.OK });
 }
 

--- a/packages/instrumentation/src/types/metrics.ts
+++ b/packages/instrumentation/src/types/metrics.ts
@@ -33,6 +33,8 @@ export const GEN_AI_METRICS = {
   // Context utilization
   CONTEXT_UTILIZATION: "gen_ai.toad_eye.context_utilization",
   CONTEXT_BLOCKED: "gen_ai.toad_eye.context.blocked",
+  // Thinking/reasoning models
+  THINKING_RATIO: "gen_ai.toad_eye.thinking.ratio",
   // MCP metrics
   MCP_TOOL_DURATION: "gen_ai.mcp.tool.duration",
   MCP_TOOL_CALLS: "gen_ai.mcp.tool.calls",

--- a/scripts/validate-dashboards.ts
+++ b/scripts/validate-dashboards.ts
@@ -29,6 +29,8 @@ const KNOWN_METRICS = new Set([
   "gen_ai_mcp_tool_duration",
   // Histograms (unit: USD) → _USD_sum, _count, _bucket
   "gen_ai_client_request_cost_USD",
+  // Histograms (no unit)
+  "gen_ai_toad_eye_thinking_ratio",
   // Counters → _total
   "gen_ai_client_token_usage_total",
   "gen_ai_client_requests_total",


### PR DESCRIPTION
## Summary

Support for thinking/reasoning models (o1/o3, Claude extended thinking, Gemini thinking):

- `LLMCallOutput` accepts `thinkingContent` and `thinkingTokens`
- `gen_ai.usage.reasoning_tokens` span attribute (OTel semconv aligned)
- `gen_ai.toad_eye.thinking.ratio` — thinking tokens / total output (span attr + Prometheus metric)
- `gen_ai.thinking` span event with thinking content (visible in Jaeger as expandable block)
- Thinking content respects `recordContent` privacy setting
- `gen_ai.toad_eye.thinking.content_length` always recorded regardless of privacy

Closes #39

## Test plan

- [x] Build passes
- [x] 285 tests pass
- [x] Dashboard validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)